### PR TITLE
Build for Windows on MinGW

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -9,7 +9,8 @@
   (language c)
   (names c_generated_functions helpers)
   (include_dirs vendor/libuv/include))
- (foreign_archives uv))
+ (foreign_archives uv)
+ (c_library_flags (:include extra_libs.sexp)))
 
 
 
@@ -32,9 +33,18 @@
   (ignore-outputs (bash
    "cp vendor/libuv/libuv.so.1.0.0 dlluv.so || \
     cp vendor/libuv/libuv.1.dylib dlluv.so || \
-    cp vendor/libuv/libuv.dll.a dlluv.dll")))))
+    cp vendor/bin/libuv-1.dll dlluv.dll")))))
 
 (data_only_dirs vendor)
+
+(rule
+ (targets extra_libs.sexp)
+ (action (ignore-outputs (bash "\
+   if ocamlc -config | grep mingw; then \
+     echo '(-liphlpapi -lpsapi -luserenv)' > extra_libs.sexp; \
+   else \
+     echo '()' > extra_libs.sexp; \
+   fi"))))
 
 
 
@@ -64,7 +74,7 @@
  (deps (:c generate_types_step_2.c) helpers.h)
  (action (bash "\
   %{cc} %{c} \
-  -I `dirname %{lib:ctypes:ctypes_cstubs_internals.h}` \
+  -I '%{lib:ctypes:.}' \
   -I %{ocaml_where} \
   -I vendor/libuv/include -o %{targets}")))
 

--- a/src/c/generate_c_functions.ml
+++ b/src/c/generate_c_functions.ml
@@ -4,6 +4,7 @@
 
 
 let () =
+  print_endline "#include \"windows_version.h\"";
   print_endline "#include <memory.h>";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";

--- a/src/c/generate_types_start.ml
+++ b/src/c/generate_types_start.ml
@@ -4,6 +4,7 @@
 
 
 let () =
+  print_endline "#include \"windows_version.h\"";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";
   print_endline "#include <uv.h>";

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -17,6 +17,23 @@
 
 
 
+#ifdef _WIN32
+#ifndef S_ISUID
+#define S_ISUID 0
+#endif
+#ifndef S_ISGID
+#define S_ISGID 0
+#endif
+#ifndef S_ISVTX
+#define S_ISVTX 0
+#endif
+#ifndef SIGPROF
+#define SIGPROF 0
+#endif
+#endif
+
+
+
 // Callback trampolines.
 //
 // We need to pass C function pointers to libuv, but call OCaml callbacks.

--- a/src/c/windows_version.h
+++ b/src/c/windows_version.h
@@ -1,0 +1,19 @@
+// This file is part of Luv, released under the MIT license. See LICENSE.md for
+// details, or visit https://github.com/aantron/luv/blob/master/LICENSE.md.
+
+
+
+#pragma once
+
+#ifndef LUV_WINDOWS_VERSION_H_
+#define LUV_WINDOWS_VERSION_H_
+
+#ifdef _WIN32
+#include <WinSDKVer.h>
+#define WINVER _WIN32_WINNT_VISTA
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#include <sdkddkver.h>
+#include <ws2tcpip.h>
+#endif
+
+#endif // #ifndef LUV_WINDOWS_VERSION_H_


### PR DESCRIPTION
@bryphe, I've been working on getting a build to finish with opam + bare opam-repository-mingw in Cygwin for now, as I have to debug my Windows esy to try esy instead. Most or all of the needed fixes are likely to be the same between the two environments, anyway. They are also similar to your work in #44, but a bit more "conservative" in the sense of minor things like not calling `ocamlfind`, etc.

This commit already builds the Luv library, but the test cases currently fail to link with:

```
** Cannot resolve symbols for src/c\libuv.a(libuv_la-getaddrinfo.o/
libuv_la-getnameinfo.o/
libuv_la-handle.o/
libuv_la-loop-watcher.o/
libuv_la-process-stdio.o/
libuv_la-process.o/
libuv_la-signal.o/
libuv_la-stream.o/
libuv_la-thread.o/
libuv_la-winapi.o/
libuv_la-winsock.o/
):
 ConvertInterfaceIndexToLuid
 ConvertInterfaceLuidToNameW
** Cannot resolve symbols for src/c\libuv.a(libuv_la-util.o):
 GetAdaptersAddresses
 GetProcessMemoryInfo
** Cannot resolve symbols for descriptor object:
 GetUserProfileDirectoryW
```

I will continue debugging that tomorrow, but in the meantime, have you observed that while working on your version of the patch?