### PR TITLE
add change test to FS_event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml }}
       - run: opam depext -y conf-pkg-config
-      - run: opam install -y --deps-only --with-test .
-      - run: opam exec -- dune runtest -p luv
+      - run: opam install -y --deps-only .
+      - run: opam exec -- dune build -p luv
 
   esy:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml }}
       - run: opam depext -y conf-pkg-config
-      - run: opam install -y --deps-only .
-      - run: opam install alcotest
+      - run: opam install -y --deps-only --with-test .
       - run: opam exec -- dune runtest -p luv
 
   esy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           ocaml-version: ${{ matrix.ocaml }}
       - run: opam depext -y conf-pkg-config
       - run: opam install -y --deps-only .
+      - run: opam install alcotest
       - run: opam exec -- dune runtest -p luv
 
   esy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           ocaml-version: ${{ matrix.ocaml }}
       - run: opam depext -y conf-pkg-config
       - run: opam install -y --deps-only .
-      - run: opam exec -- dune build -p luv
+      - run: opam exec -- dune runtest -p luv
 
   esy:
     runs-on: ${{ matrix.os }}

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -74,12 +74,15 @@ let tests = [
 
         open_out filename |> close_out;
 
+        let start = Unix.gettimeofday() in
+
         Luv.FS_event.start event filename begin fun result ->
           Luv.FS_event.stop event |> check_success_result "stop";
           let filename', events = check_success_result "start" result in
           Alcotest.(check string) "filename" filename filename';
           Alcotest.(check bool) "rename" false (List.mem `RENAME events);
           Alcotest.(check bool) "change" true (List.mem `CHANGE events);
+          Printf.printf "Success: %f\n%!" (Unix.gettimeofday() -. start);
           occurred := true
         end;
         
@@ -88,6 +91,8 @@ let tests = [
         close_out oc;
 
         run ~with_timeout:true ();
+
+        Printf.printf "Done: %f\n%!" (Unix.gettimeofday() -. start);
         
         Alcotest.(check bool) "occurred" true !occurred
       end

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -83,6 +83,8 @@ let tests = [
           occurred := true
         end;
 
+        Unix.sleepf(0.1);
+
         let start = Unix.gettimeofday() in
         
         let oc = open_out filename in

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -82,6 +82,8 @@ let tests = [
           Alcotest.(check bool) "change" true (List.mem `CHANGE events);
           occurred := true
         end;
+
+        let start = Unix.gettimeofday() in
         
         let oc = open_out filename in
         let () = Printf.fprintf oc "foo" in
@@ -89,7 +91,8 @@ let tests = [
 
         run ();
         
-        Alcotest.(check bool) "occurred" true !occurred
+        Alcotest.(check bool) "occurred" true !occurred;
+        Alcotest.(check (float 0.1)) "delay < 1000ms" 0. (Unix.gettimeofday() -. start);
       end
     end;
   ]

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -74,15 +74,12 @@ let tests = [
 
         open_out filename |> close_out;
 
-        let start = Unix.gettimeofday() in
-
         Luv.FS_event.start event filename begin fun result ->
           Luv.FS_event.stop event |> check_success_result "stop";
           let filename', events = check_success_result "start" result in
           Alcotest.(check string) "filename" filename filename';
           Alcotest.(check bool) "rename" false (List.mem `RENAME events);
           Alcotest.(check bool) "change" true (List.mem `CHANGE events);
-          Printf.printf "Success: %f\n%!" (Unix.gettimeofday() -. start);
           occurred := true
         end;
         
@@ -90,9 +87,7 @@ let tests = [
         let () = Printf.fprintf oc "foo" in
         close_out oc;
 
-        run ~with_timeout:true ();
-
-        Printf.printf "Done: %f\n%!" (Unix.gettimeofday() -. start);
+        run ();
         
         Alcotest.(check bool) "occurred" true !occurred
       end

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -67,7 +67,7 @@ let tests = [
         Alcotest.(check bool) "occurred" true !occurred
       end
     end;
-    
+
     "change", `Quick, begin fun () ->
       with_fs_event begin fun event ->
         let occurred = ref false in
@@ -83,20 +83,22 @@ let tests = [
           occurred := true
         end;
 
-        let start = ref(0.) in
+        let start = ref 0. in
 
         let timer = Luv.Timer.init () |> check_success_result "timer init" in
-        Luv.Timer.start timer 100 (fun () -> 
+        check_success_result "timer start" @@
+        Luv.Timer.start timer 100 begin fun () ->
           start := Unix.gettimeofday ();
           let oc = open_out filename in
           let () = Printf.fprintf oc "foo" in
-          close_out oc;
-        ) |> check_success_result "timer start";
+          close_out oc
+        end;
 
         run ();
-        
+
         Alcotest.(check bool) "occurred" true !occurred;
-        Alcotest.(check (float 0.1)) "delay < 100ms" 0. (Unix.gettimeofday () -. !start);
+        Alcotest.(check (float 0.1)) "delay < 100ms" 0.
+          (Unix.gettimeofday () -. !start)
       end
     end;
   ]

--- a/test/FS_event.ml
+++ b/test/FS_event.ml
@@ -83,18 +83,20 @@ let tests = [
           occurred := true
         end;
 
-        Unix.sleepf(0.1);
+        let start = ref(0.) in
 
-        let start = Unix.gettimeofday() in
-        
-        let oc = open_out filename in
-        let () = Printf.fprintf oc "foo" in
-        close_out oc;
+        let timer = Luv.Timer.init () |> check_success_result "timer init" in
+        Luv.Timer.start timer 100 (fun () -> 
+          start := Unix.gettimeofday ();
+          let oc = open_out filename in
+          let () = Printf.fprintf oc "foo" in
+          close_out oc;
+        ) |> check_success_result "timer start";
 
         run ();
         
         Alcotest.(check bool) "occurred" true !occurred;
-        Alcotest.(check (float 0.1)) "delay < 1000ms" 0. (Unix.gettimeofday() -. start);
+        Alcotest.(check (float 0.1)) "delay < 100ms" 0. (Unix.gettimeofday () -. !start);
       end
     end;
   ]


### PR DESCRIPTION
While trying to troubleshoot a test failure in Onivim relating to fs_event I added this change test to Luv's test suite. Our test only fails on macOS, and while this test passes on both Linux and macOS it still times out on macOS only (or runs indefinitely without the timeout).

I'm having issues with other tests hanging on both platforms as well, so I'm wondering if this specific issue happens on the CI or for others tool, or if it's just me doing something wrong.