### PR TITLE
Add st_mode properties for Fs.stat

### DIFF
--- a/src/c/luv_c_type_descriptions.ml
+++ b/src/c/luv_c_type_descriptions.ml
@@ -401,6 +401,14 @@ struct
       let isuid = constant "S_ISUID" int
       let isgid = constant "S_ISGID" int
       let isvtx = constant "S_ISVTX" int
+
+      let ifmt = constant "S_IFMT" int
+      let ifsock = constant "S_IFSOCK" int
+      let ifdir = constant "S_IFDIR" int
+      let ifblk = constant "S_IFBLK" int
+      let ifchr = constant "S_IFCHR" int
+      let iflnk = constant "S_IFLNK" int
+      let ififo = constant "S_IFIFO" int
     end
 
     module Dirent =

--- a/src/c/luv_c_type_descriptions.ml
+++ b/src/c/luv_c_type_descriptions.ml
@@ -403,7 +403,6 @@ struct
       let isvtx = constant "S_ISVTX" int
 
       let ifmt = constant "S_IFMT" int
-      let ifsock = constant "S_IFSOCK" int
       let ifdir = constant "S_IFDIR" int
       let ifblk = constant "S_IFBLK" int
       let ifchr = constant "S_IFCHR" int

--- a/src/file.ml
+++ b/src/file.ml
@@ -126,7 +126,6 @@ struct
     | `ISVTX
 
     | `IFMT
-    | `IFSOCK
     | `IFDIR
     | `IFBLK
     | `IFCHR
@@ -157,7 +156,6 @@ struct
     | `ISVTX -> isvtx
 
     | `IFMT -> ifmt
-    | `IFSOCK -> ifsock
     | `IFDIR -> ifdir
     | `IFBLK -> ifblk
     | `IFCHR -> ifchr

--- a/src/file.ml
+++ b/src/file.ml
@@ -125,6 +125,14 @@ struct
     | `ISGID
     | `ISVTX
 
+    | `IFMT
+    | `IFSOCK
+    | `IFDIR
+    | `IFBLK
+    | `IFCHR
+    | `IFLNK
+    | `IFIFO
+
     | `NUMERIC of int
   ]
 
@@ -147,6 +155,14 @@ struct
     | `ISUID -> isuid
     | `ISGID -> isgid
     | `ISVTX -> isvtx
+
+    | `IFMT -> ifmt
+    | `IFSOCK -> ifsock
+    | `IFDIR -> ifdir
+    | `IFBLK -> ifblk
+    | `IFCHR -> ifchr
+    | `IFLNK -> iflnk
+    | `IFIFO -> ififo
 
     | `NUMERIC i -> i
 

--- a/src/file.mli
+++ b/src/file.mli
@@ -168,6 +168,14 @@ sig
     | `ISGID
     | `ISVTX
 
+    | `IFMT
+    | `IFSOCK
+    | `IFDIR
+    | `IFBLK
+    | `IFCHR
+    | `IFLNK
+    | `IFIFO
+
     | `NUMERIC of int
   ]
   (** The bits.

--- a/src/file.mli
+++ b/src/file.mli
@@ -169,7 +169,6 @@ sig
     | `ISVTX
 
     | `IFMT
-    | `IFSOCK
     | `IFDIR
     | `IFBLK
     | `IFCHR


### PR DESCRIPTION
Based on discussion in #68 - this adds additional properties for querying the `Mode.t` returned by the `stat` API. This is important for determining if the requested path is a directory, symlink, or file. Tested on OSX and Windows (MingW64)

Fixes #68 