### PR TITLE
Add S_IFREG to Mode

### DIFF
--- a/src/c/luv_c_type_descriptions.ml
+++ b/src/c/luv_c_type_descriptions.ml
@@ -403,6 +403,7 @@ struct
       let isvtx = constant "S_ISVTX" int
 
       let ifmt = constant "S_IFMT" int
+      let ifreg = constant "S_IFREG" int
       let ifdir = constant "S_IFDIR" int
       let ifblk = constant "S_IFBLK" int
       let ifchr = constant "S_IFCHR" int

--- a/src/file.ml
+++ b/src/file.ml
@@ -126,6 +126,7 @@ struct
     | `ISVTX
 
     | `IFMT
+    | `IFREG
     | `IFDIR
     | `IFBLK
     | `IFCHR
@@ -156,6 +157,7 @@ struct
     | `ISVTX -> isvtx
 
     | `IFMT -> ifmt
+    | `IFREG -> ifreg
     | `IFDIR -> ifdir
     | `IFBLK -> ifblk
     | `IFCHR -> ifchr

--- a/src/file.mli
+++ b/src/file.mli
@@ -169,6 +169,7 @@ sig
     | `ISVTX
 
     | `IFMT
+    | `IFREG
     | `IFDIR
     | `IFBLK
     | `IFCHR


### PR DESCRIPTION
Missed the `S_IFREG` constant in https://github.com/aantron/luv/pull/69 - this adds it, so that `Luv.File.stat` can be used to check if the stat result represents a file.