### PR TITLE
fix(windows): Intermittent crash on `Luv.Process.spawn`

### DIFF
--- a/src/c/luv_c_function_descriptions.ml
+++ b/src/c/luv_c_function_descriptions.ml
@@ -1197,13 +1197,13 @@ struct
         (ptr Loop.t @->
          ptr t @->
          exit_cb @->
-         ocaml_string @->
-         ptr string @->
+         ptr char @->
+         ptr (ptr char) @->
          int @->
-         ptr string @->
+         ptr (ptr char) @->
          int @->
          bool @->
-         ocaml_string @->
+         ptr char @->
          bool @->
          int @->
          int @->

--- a/src/process.ml
+++ b/src/process.ml
@@ -78,6 +78,11 @@ let null_callback =
   C.Functions.Process.get_null_callback ()
 
 let c_string_array strings =
+  (*
+    The array-of-pointers doesn't hold a reference to the individual string pointers,
+    so we need to allocate and return them so the consumer can ensure they stayed
+    referenced to avoid the GC cleaning them up early.
+  *)
   let c_string_ptrs = strings @ [""]
     |> List.map Ctypes.(CArray.of_string) 
     |> List.map Ctypes.CArray.start
@@ -165,6 +170,12 @@ let spawn
   let c_cwd = cwd |> Ctypes.(CArray.of_string) |> Ctypes.CArray.start in
   let c_path = path |> Ctypes.(CArray.of_string) |> Ctypes.CArray.start in
 
+  (*
+    Ensure that the GC maintains handles to all the strings we're passing through the duration of the call.
+
+    This is important because the runtime is released, and there is a potential race condition if the
+    GC is triggered between releasing the runtime and calling [uv_spawn].
+  *)
   let gc_handles = ref (Some (gc_arg_handles, gc_env_handles, c_cwd, c_path)) in
 
   let result =


### PR DESCRIPTION
This is a fix for an intermittent crash occurring when calling `Luv.Process.spawn`.

This crash was observed while working on Onivim 2 on Windows - when running with `esy run -f`, the process would crash fairly reliably (~80%) at `Luv.Process.spawn`. Interestingly, this _did not_ reproduce when disabling logging, or when logging with `--trace` - this led me to suspect a GC integration issue (the differing log levels change the pattern of allocations, so if there is a crash in a particular log level, it's likely that a particular allocation pattern is getting us to that crash...)

Using `fprintf`s, I could confirm that the crash occurred during the call to `uv_spawn` here: https://github.com/aantron/luv/blob/59a5418145bc6af3570ec5341d108f8df4e4da35/src/c/helpers.c#L648

Upon experimenting - it seems that there is no guarantee that the strings or string arrays passed are 'pinned' in memory - the GC could, potentially, move the values around when the runtime system is released, and I believe this is the case I was hitting with `esy run -f` - it happened to be the compaction happened in a way to shuffle the strings around. Both the `CArray` and string pointers seem to be to OCaml-managed strings (ie, given by `String_val`)

According the [FFI docs](https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html) here:
```
After caml_release_runtime_system() was called and until caml_acquire_runtime_system() is called, the C code must not access any OCaml data, nor call any function of the run-time system, nor call back into OCaml code. Consequently, arguments provided by OCaml to the C primitive must be copied into C data structures before calling caml_release_runtime_system(), and results to be returned to OCaml must be encoded as OCaml values after caml_acquire_runtime_system() returns.
```
we should be making sure we aren't accessing OCaml-managed values when the runtime system is released, and I believe we are in this case. It might be there's a different type to use for ctypes to handle this (`string` vs `ocaml_string`) - but I'm not an expert in ctypes, so perhaps there is a cleaner fix.

This proposed change allocates C-managed memory for `cwd`, `file_path`, `args`, and `env`, and uses the c-managed memory, which won't be pulled out from underneath us like the OCaml-managed memory could be. Once the process is spawned, we can free that memory.

