### PR TITLE
Support building with older versions of libuv that may be installed on the system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ check-ejected-build :
 	   echo; \
 	   false)
 
+.PHONY : install-autotools
+install-autotools :
+	sudo apt install automake libtool
+
 .PHONY : docs
 docs : api-docs luvbook
 

--- a/src/TCP.mli
+++ b/src/TCP.mli
@@ -31,8 +31,8 @@ val init :
     The stream is not yet connected or listening. See {!Luv.TCP.bind},
     {!Luv.Stream.listen}, and {!Luv.Stream.connect}.
 
-    On libuv prior to 1.7.0, [?domain] is ignored, and the function behaves as
-    {{:http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_init} [uv_tcp_init]}.
+    On libuv prior to 1.7.0, using [?domain] causes this function to return
+    [Error `ENOSYS] ("Function not implemented").
 
     {{!Luv.Require} Feature check}: [Luv.Require.(has tcp_init_ex)] *)
 

--- a/src/TCP.mli
+++ b/src/TCP.mli
@@ -29,7 +29,12 @@ val init :
     [uv_tcp_init_ex]}.
 
     The stream is not yet connected or listening. See {!Luv.TCP.bind},
-    {!Luv.Stream.listen}, and {!Luv.Stream.connect}. *)
+    {!Luv.Stream.listen}, and {!Luv.Stream.connect}.
+
+    On libuv prior to 1.7.0, [?domain] is ignored, and the function behaves as
+    {{:http://docs.libuv.org/en/v1.x/tcp.html#c.uv_tcp_init} [uv_tcp_init]}.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has tcp_init_ex)] *)
 
 val open_ : t -> Os_fd.Socket.t -> (unit, Error.t) result
 (** Wraps an existing socket in a libuv TCP stream.

--- a/src/TTY.mli
+++ b/src/TTY.mli
@@ -66,8 +66,16 @@ end
 
 val set_vterm_state : Vterm_state.t -> unit
 (** Binds {{:http://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_set_vterm_state}
-    [uv_tty_set_vterm_state]}. *)
+    [uv_tty_set_vterm_state]}.
+
+    Requires libuv 1.33.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has tty_vterm_state)] *)
 
 val get_vterm_state : unit -> (Vterm_state.t, Error.t) result
 (** Binds {{:http://docs.libuv.org/en/v1.x/tty.html#c.uv_tty_get_vterm_state}
-    [uv_tty_get_vterm_state]}. *)
+    [uv_tty_get_vterm_state]}.
+
+    Requires libuv 1.33.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has tty_vterm_state)] *)

--- a/src/UDP.mli
+++ b/src/UDP.mli
@@ -24,7 +24,14 @@ val init :
     Binds {{:http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_init_ex}
     [uv_udp_init_ex]}.
 
-    [?recvmmsg] is available since Luv 0.5.2 (libuv 1.37.0). *)
+    [?domain] requires libuv 1.7.0.
+
+    [?recvmmsg] is requires Luv 0.5.2 and libuv 1.37.0.
+
+    {{!Luv.Require} Feature checks}:
+
+    - [Luv.Require.(has udp_init_ex)]
+    - [Luv.Require.(has udp_recvmmg)] *)
 
 val open_ : t -> Os_fd.Socket.t -> (unit, Error.t) result
 (** Wraps an existing socket in a libuv UDP handle.
@@ -74,7 +81,12 @@ val set_source_membership :
 
     Binds
     {{:http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_set_source_membership}
-    [uv_udp_set_source_membership]}. *)
+    [uv_udp_set_source_membership]}.
+
+    Requires libuv 1.32.0.
+
+    {{!Luv.Require} Feature check}:
+    [Luv.Require.(has udp_set_source_membership)] *)
 
 val set_multicast_loop : t -> bool -> (unit, Error.t) result
 (** Sets multicast loopback.
@@ -139,9 +151,14 @@ sig
     | `MMSG_CHUNK
     | `MMSG_FREE
   ]
-  (** [`MMSG_CHUNK] is possible since Luv 0.5.1 (libuv 1.35.0).
+  (** [`MMSG_CHUNK] occurs since Luv 0.5.1 and libuv 1.35.0.
 
-      [`MMSG_FREE] is possible since Luv 0.5.6 (libuv 1.40.0). *)
+      [`MMSG_FREE] occurs since Luv 0.5.6 and libuv 1.40.0.
+
+      {{!Luv.Require} Feature checks}:
+
+      - [Luv.Require.(has mmsg_chunk)]
+      - [Luv.Require.(has mmsg_free)] *)
 end
 
 val recv_start :
@@ -203,7 +220,9 @@ val using_recvmmsg : t -> bool
     Binds {{:http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_using_recvmmsg}
     [uv_udp_using_recvmmsg]}.
 
-    @since Luv 0.5.5 (libuv 1.39.0) *)
+    Requires Luv 0.5.5 and libuv 1.39.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has udp_using_recvmmsg)] *)
 
 val get_send_queue_size : t -> int
 (** Binds
@@ -215,7 +234,11 @@ val get_send_queue_count : t -> int
     {{:http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_get_send_queue_count}
     [uv_udp_get_send_queue_count]}. *)
 
-(** Connected UDP sockets. *)
+(** Connected UDP sockets.
+
+    This module requires libuv 1.27.0 or higher.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has udp_connect)] *)
 module Connected :
 sig
   val connect : t -> Sockaddr.t -> (unit, Error.t) result

--- a/src/UDP.mli
+++ b/src/UDP.mli
@@ -24,9 +24,11 @@ val init :
     Binds {{:http://docs.libuv.org/en/v1.x/udp.html#c.uv_udp_init_ex}
     [uv_udp_init_ex]}.
 
-    [?domain] requires libuv 1.7.0.
+    On libuv prior to 1.7.0, using [?domain] causes this function to return
+    [Error `ENOSYS] ("Function not implemented").
 
-    [?recvmmsg] is requires Luv 0.5.2 and libuv 1.37.0.
+    [?recvmmsg] is requires Luv 0.5.2 and libuv 1.37.0. Passing it with earlier
+    libuv has no effect.
 
     {{!Luv.Require} Feature checks}:
 

--- a/src/c/dune
+++ b/src/c/dune
@@ -108,7 +108,7 @@ let () = Jbuild_plugin.V1.send @@ {|
 ;   https://github.com/avsm/ocaml-yaml/blob/master/types/stubgen/jbuild#L20
 (rule
  (targets generate_types_step_2.exe)
- (deps (:c generate_types_step_2.c) helpers.h)
+ (deps (:c generate_types_step_2.c) helpers.h shims.h)
  (action (bash "\
   %{cc} %{c} \
   -I '%{lib:ctypes:.}' \

--- a/src/c/dune
+++ b/src/c/dune
@@ -1,6 +1,6 @@
 (* -*- tuareg -*- *)
 
-let foreign_archives, uv_library_flag, include_dirs =
+let foreign_archives, uv_library_flag, include_dirs, i_option =
   let use_system_libuv =
     match Sys.getenv "LUV_USE_SYSTEM_LIBUV" with
     | "yes" -> true
@@ -9,9 +9,15 @@ let foreign_archives, uv_library_flag, include_dirs =
   in
 
   if use_system_libuv then
-    "", "-luv", ""
+    "",
+    "-luv",
+    "",
+    ""
   else
-    "(foreign_archives uv)", "", "(include_dirs vendor/libuv/include)"
+    "(foreign_archives uv)",
+    "",
+    "(include_dirs vendor/libuv/include)",
+    "-I vendor/libuv/include"
 
 let () = Jbuild_plugin.V1.send @@ {|
 
@@ -113,7 +119,7 @@ let () = Jbuild_plugin.V1.send @@ {|
   %{cc} %{c} \
   -I '%{lib:ctypes:.}' \
   -I %{ocaml_where} \
-  -I vendor/libuv/include -o %{targets}")))
+  |}^ i_option ^{| -o %{targets}")))
 
 (rule
  (with-stdout-to luv_c_generated_types.ml

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -14,6 +14,7 @@
 
 #include <caml/mlvalues.h>
 #include <uv.h>
+#include "shims.h"
 
 
 

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,13 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 10
+    static int uv_translate_sys_error(int sys_error)
+    {
+        return 0x34242424;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 12
     static int uv_loop_fork(uv_loop_t* loop)
     {

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -1,0 +1,13 @@
+// This file is part of Luv, released under the MIT license. See LICENSE.md for
+// details, or visit https://github.com/aantron/luv/blob/master/LICENSE.md.
+
+
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 40
+    #define UV_UDP_MMSG_FREE 0
+
+    static uint64_t uv_timer_get_due_in(const uv_timer_t *timer)
+    {
+        return 0;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,13 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 15
+    static int uv_mutex_init_recursive(uv_mutex_t *mutex)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 16
     #define UV_ENOTTY 0x24242424
 

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -261,3 +261,69 @@
     #define UV_FS_COPYFILE_FICLONE 0
     #define UV_FS_COPYFILE_FICLONE_FORCE 0
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 19
+    static uv_loop_t* uv_handle_get_loop(const uv_handle_t *handle)
+    {
+        return handle->loop;
+    }
+    static void* uv_handle_get_data(const uv_handle_t *handle)
+    {
+        return handle->data;
+    }
+    static void* uv_handle_set_data(uv_handle_t *handle, void *data)
+    {
+        handle->data = data;
+        return data;
+    }
+
+    static void* uv_req_get_data(const uv_req_t *request)
+    {
+        return request->data;
+    }
+    static void* uv_req_set_data(uv_req_t *request, void *data)
+    {
+        request->data = data;
+        return data;
+    }
+    static const char* uv_req_type_name(uv_req_type type)
+    {
+        return NULL;
+    }
+
+    static size_t uv_stream_get_write_queue_size(const uv_stream_t *stream)
+    {
+        return stream->write_queue_size;
+    }
+
+    static size_t uv_udp_get_send_queue_size(const uv_udp_t *udp)
+    {
+        return udp->send_queue_size;
+    }
+    static size_t uv_udp_get_send_queue_count(const uv_udp_t *udp)
+    {
+        return udp->send_queue_count;
+    }
+
+    static uv_pid_t uv_process_get_pid(const uv_process_t *process)
+    {
+        return process->pid;
+    }
+
+    static ssize_t uv_fs_get_result(const uv_fs_t *request)
+    {
+        return request->result;
+    }
+    static void* uv_fs_get_ptr(const uv_fs_t *request)
+    {
+        return request->ptr;
+    }
+    static const char* uv_fs_get_path(const uv_fs_t *request)
+    {
+        return request->path;
+    }
+    static uv_stat_t* uv_fs_get_statbuf(uv_fs_t *request)
+    {
+        return &request->statbuf;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,25 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 7
+    #define UV_VERSION_HEX \
+        ((UV_VERSION_MAJOR << 16) | \
+         (UV_VERSION_MINOR <<  8) | \
+         (UV_VERSION_PATCH))
+
+    static int uv_tcp_init_ex(
+        uv_loop_t *loop, uv_tcp_t *tcp, unsigned int flags)
+    {
+        return uv_tcp_init(loop, tcp);
+    }
+
+    static int uv_udp_init_ex(
+        uv_loop_t *loop, uv_udp_t *udp, unsigned int flags)
+    {
+        return uv_udp_init(loop, udp);
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 8
     static int uv_fs_realpath(
         uv_loop_t *loop, uv_fs_t *request, const char *path, uv_fs_cb callback)

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -82,3 +82,20 @@
         return ENOTSUP;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 32
+    #define UV_EILSEQ 0x04242424
+
+    static int uv_tcp_close_reset(uv_tcp_t *handle, uv_close_cb close_callback)
+    {
+        return ENOSYS;
+    }
+
+    static int uv_udp_set_source_membership(
+        uv_udp_t *handle, const char *multicast_addr,
+        const char *interface_addr, const char *source_addr,
+        uv_membership membership)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,13 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 6
+    static int uv_os_homedir(char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 7
     #define UV_VERSION_HEX \
         ((UV_VERSION_MAJOR << 16) | \

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -135,3 +135,28 @@
         return 0;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 28
+    typedef struct {int64_t tv_sec; int32_t tv_usec;} uv_timeval64_t;
+    static int uv_gettimeofday(uv_timeval64_t *tv)
+    {
+        return ENOSYS;
+    }
+
+    typedef struct {uv_dirent_t *dirents; size_t nentries;} uv_dir_t;
+    static int uv_fs_opendir(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+    static int uv_fs_closedir(
+        uv_loop_t *loop, uv_fs_t *request, uv_dir_t *dir, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+    static int uv_fs_readdir(
+        uv_loop_t *loop, uv_fs_t *request, uv_dir_t* dir, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -244,3 +244,15 @@
         return buffer;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 21
+    #define UV_EFTYPE 0x14242424
+    #define UV_OVERLAPPED_PIPE 0
+
+    static int uv_fs_lchown(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_uid_t user,
+        uv_gid_t group, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -327,3 +327,10 @@
         return &request->statbuf;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 18
+    static uv_pid_t uv_os_getpid()
+    {
+        return 0;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,263 +3,11 @@
 
 
 
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 40
-    #define UV_UDP_MMSG_FREE 0
-
-    static uint64_t uv_timer_get_due_in(const uv_timer_t *timer)
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 18
+    static uv_pid_t uv_os_getpid()
     {
         return 0;
     }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 39
-    #define UV_METRICS_IDLE_TIME 0
-
-    static uint64_t uv_metrics_idle_time(uv_loop_t *loop)
-    {
-        return 0;
-    }
-
-    static int uv_udp_using_recvmmsg(uv_udp_t *udp)
-    {
-        return 0;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 38
-    static void uv_library_shutdown()
-    {
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 37
-    #define UV_UDP_RECVMMSG 0
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 36
-    static int uv_fs_lutime(
-        uv_loop_t *loop, uv_fs_t *request, const char *path, double atime,
-        double mtime, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 35
-    #define UV_UDP_MMSG_CHUNK 0
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 34
-    static int uv_fs_mkstemp(
-        uv_loop_t *loop, uv_fs_t *request, const char *template,
-        uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-
-    static void uv_sleep(unsigned int msec)
-    {
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 33
-    typedef int uv_random_t;
-    typedef void (*uv_random_cb)(
-        uv_random_t *request, int status, void* buffer, size_t length);
-    static int uv_random(
-        uv_loop_t *loop, uv_random_t *request, void *buffer, size_t length,
-        unsigned int flags, uv_random_cb callback)
-    {
-        return ENOSYS;
-    }
-
-    typedef enum {UV_TTY_SUPPORTED, UV_TTY_UNSUPPORTED} uv_tty_vtermstate_t;
-    static void uv_tty_set_vterm_state(uv_tty_vtermstate_t state)
-    {
-    }
-    static int uv_tty_get_vterm_state(uv_tty_vtermstate_t *state)
-    {
-        return ENOTSUP;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 32
-    #define UV_EILSEQ 0x04242424
-
-    static int uv_tcp_close_reset(uv_tcp_t *handle, uv_close_cb close_callback)
-    {
-        return ENOSYS;
-    }
-
-    static int uv_udp_set_source_membership(
-        uv_udp_t *handle, const char *multicast_addr,
-        const char *interface_addr, const char *source_addr,
-        uv_membership membership)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 31
-    #define UV_FS_O_FILEMAP 0
-
-    typedef struct {
-        uint64_t f_type;
-        uint64_t f_bsize;
-        uint64_t f_blocks;
-        uint64_t f_bfree;
-        uint64_t f_bavail;
-        uint64_t f_files;
-        uint64_t f_ffree;
-        uint64_t f_spare[4];
-    } uv_statfs_t;
-    static int uv_fs_statfs(
-        uv_loop_t *loop, uv_fs_t *request, const char* path, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-
-    typedef struct {char *name; char *value;} uv_env_item_t;
-    static int uv_os_environ(uv_env_item_t **items, int *count)
-    {
-        return ENOSYS;
-    }
-    static void uv_os_free_environ(uv_env_item_t *items, int count)
-    {
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 29
-    static uint64_t uv_get_constrained_memory()
-    {
-        return 0;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 28
-    typedef struct {int64_t tv_sec; int32_t tv_usec;} uv_timeval64_t;
-    static int uv_gettimeofday(uv_timeval64_t *tv)
-    {
-        return ENOSYS;
-    }
-
-    typedef struct {uv_dirent_t *dirents; size_t nentries;} uv_dir_t;
-    static int uv_fs_opendir(
-        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-    static int uv_fs_closedir(
-        uv_loop_t *loop, uv_fs_t *request, uv_dir_t *dir, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-    static int uv_fs_readdir(
-        uv_loop_t *loop, uv_fs_t *request, uv_dir_t* dir, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 27
-    static int uv_udp_connect(uv_udp_t *udp, const struct sockaddr *addr)
-    {
-        return ENOSYS;
-    }
-    static int uv_udp_getpeername(
-        const uv_udp_t *udp, struct sockaddr *name, int *namelen)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 26
-    typedef struct {
-        enum {
-            UV_THREAD_NO_FLAGS = 0x00,
-            UV_THREAD_HAS_STACK_SIZE = 0x01
-        } flags;
-        size_t stack_size;
-    } uv_thread_options_t;
-    static int uv_thread_create_ex(
-        uv_thread_t *id, const uv_thread_options_t *options, uv_thread_cb entry,
-        void* argument)
-    {
-        return uv_thread_create(id, entry, argument);
-    }
-
-    #ifdef MAXHOSTNAMELEN
-        #define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
-    #else
-        #define UV_MAXHOSTNAMESIZE 256
-    #endif
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 25
-    typedef struct {
-        char sysname[256];
-        char release[256];
-        char version[256];
-        char machine[256];
-    } uv_utsname_t;
-    static int uv_os_uname(uv_utsname_t *buffer)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 24
-    #define UV_PROCESS_WINDOWS_HIDE_CONSOLE 0
-    #define UV_PROCESS_WINDOWS_HIDE_GUI 0
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 23
-    static int uv_open_osfhandle(uv_os_fd_t os_fd)
-    {
-        return (int)os_fd;
-    }
-
-    static int uv_os_getpriority(uv_pid_t pid, int *priority)
-    {
-        return ENOSYS;
-    }
-    static int uv_os_setpriority(uv_pid_t pid, int priority)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 22
-    static char* uv_strerror_r(int error, char *buffer, size_t length)
-    {
-        strncpy(buffer, uv_strerror(error), length - 1);
-        buffer[length] = 0;
-        return buffer;
-    }
-
-    static char* uv_err_name_r(int error, char *buffer, size_t length)
-    {
-        strncpy(buffer, uv_err_name(error), length - 1);
-        buffer[length] = 0;
-        return buffer;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 21
-    #define UV_EFTYPE 0x14242424
-    #define UV_OVERLAPPED_PIPE 0
-
-    static int uv_fs_lchown(
-        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_uid_t user,
-        uv_gid_t group, uv_fs_cb callback)
-    {
-        return ENOSYS;
-    }
-#endif
-
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 20
-    #define UV_FS_COPYFILE_FICLONE 0
-    #define UV_FS_COPYFILE_FICLONE_FORCE 0
 #endif
 
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 19
@@ -328,8 +76,260 @@
     }
 #endif
 
-#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 18
-    static uv_pid_t uv_os_getpid()
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 20
+    #define UV_FS_COPYFILE_FICLONE 0
+    #define UV_FS_COPYFILE_FICLONE_FORCE 0
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 21
+    #define UV_EFTYPE 0x14242424
+    #define UV_OVERLAPPED_PIPE 0
+
+    static int uv_fs_lchown(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_uid_t user,
+        uv_gid_t group, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 22
+    static char* uv_strerror_r(int error, char *buffer, size_t length)
+    {
+        strncpy(buffer, uv_strerror(error), length - 1);
+        buffer[length] = 0;
+        return buffer;
+    }
+
+    static char* uv_err_name_r(int error, char *buffer, size_t length)
+    {
+        strncpy(buffer, uv_err_name(error), length - 1);
+        buffer[length] = 0;
+        return buffer;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 23
+    static int uv_open_osfhandle(uv_os_fd_t os_fd)
+    {
+        return (int)os_fd;
+    }
+
+    static int uv_os_getpriority(uv_pid_t pid, int *priority)
+    {
+        return ENOSYS;
+    }
+    static int uv_os_setpriority(uv_pid_t pid, int priority)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 24
+    #define UV_PROCESS_WINDOWS_HIDE_CONSOLE 0
+    #define UV_PROCESS_WINDOWS_HIDE_GUI 0
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 25
+    typedef struct {
+        char sysname[256];
+        char release[256];
+        char version[256];
+        char machine[256];
+    } uv_utsname_t;
+    static int uv_os_uname(uv_utsname_t *buffer)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 26
+    typedef struct {
+        enum {
+            UV_THREAD_NO_FLAGS = 0x00,
+            UV_THREAD_HAS_STACK_SIZE = 0x01
+        } flags;
+        size_t stack_size;
+    } uv_thread_options_t;
+    static int uv_thread_create_ex(
+        uv_thread_t *id, const uv_thread_options_t *options, uv_thread_cb entry,
+        void* argument)
+    {
+        return uv_thread_create(id, entry, argument);
+    }
+
+    #ifdef MAXHOSTNAMELEN
+        #define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
+    #else
+        #define UV_MAXHOSTNAMESIZE 256
+    #endif
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 27
+    static int uv_udp_connect(uv_udp_t *udp, const struct sockaddr *addr)
+    {
+        return ENOSYS;
+    }
+    static int uv_udp_getpeername(
+        const uv_udp_t *udp, struct sockaddr *name, int *namelen)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 28
+    typedef struct {int64_t tv_sec; int32_t tv_usec;} uv_timeval64_t;
+    static int uv_gettimeofday(uv_timeval64_t *tv)
+    {
+        return ENOSYS;
+    }
+
+    typedef struct {uv_dirent_t *dirents; size_t nentries;} uv_dir_t;
+    static int uv_fs_opendir(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+    static int uv_fs_closedir(
+        uv_loop_t *loop, uv_fs_t *request, uv_dir_t *dir, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+    static int uv_fs_readdir(
+        uv_loop_t *loop, uv_fs_t *request, uv_dir_t* dir, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 29
+    static uint64_t uv_get_constrained_memory()
+    {
+        return 0;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 31
+    #define UV_FS_O_FILEMAP 0
+
+    typedef struct {
+        uint64_t f_type;
+        uint64_t f_bsize;
+        uint64_t f_blocks;
+        uint64_t f_bfree;
+        uint64_t f_bavail;
+        uint64_t f_files;
+        uint64_t f_ffree;
+        uint64_t f_spare[4];
+    } uv_statfs_t;
+    static int uv_fs_statfs(
+        uv_loop_t *loop, uv_fs_t *request, const char* path, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    typedef struct {char *name; char *value;} uv_env_item_t;
+    static int uv_os_environ(uv_env_item_t **items, int *count)
+    {
+        return ENOSYS;
+    }
+    static void uv_os_free_environ(uv_env_item_t *items, int count)
+    {
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 32
+    #define UV_EILSEQ 0x04242424
+
+    static int uv_tcp_close_reset(uv_tcp_t *handle, uv_close_cb close_callback)
+    {
+        return ENOSYS;
+    }
+
+    static int uv_udp_set_source_membership(
+        uv_udp_t *handle, const char *multicast_addr,
+        const char *interface_addr, const char *source_addr,
+        uv_membership membership)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 33
+    typedef int uv_random_t;
+    typedef void (*uv_random_cb)(
+        uv_random_t *request, int status, void* buffer, size_t length);
+    static int uv_random(
+        uv_loop_t *loop, uv_random_t *request, void *buffer, size_t length,
+        unsigned int flags, uv_random_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    typedef enum {UV_TTY_SUPPORTED, UV_TTY_UNSUPPORTED} uv_tty_vtermstate_t;
+    static void uv_tty_set_vterm_state(uv_tty_vtermstate_t state)
+    {
+    }
+    static int uv_tty_get_vterm_state(uv_tty_vtermstate_t *state)
+    {
+        return ENOTSUP;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 34
+    static int uv_fs_mkstemp(
+        uv_loop_t *loop, uv_fs_t *request, const char *template,
+        uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    static void uv_sleep(unsigned int msec)
+    {
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 35
+    #define UV_UDP_MMSG_CHUNK 0
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 36
+    static int uv_fs_lutime(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, double atime,
+        double mtime, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 37
+    #define UV_UDP_RECVMMSG 0
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 38
+    static void uv_library_shutdown()
+    {
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 39
+    #define UV_METRICS_IDLE_TIME 0
+
+    static uint64_t uv_metrics_idle_time(uv_loop_t *loop)
+    {
+        return 0;
+    }
+
+    static int uv_udp_using_recvmmsg(uv_udp_t *udp)
+    {
+        return 0;
+    }
+#endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 40
+    #define UV_UDP_MMSG_FREE 0
+
+    static uint64_t uv_timer_get_due_in(const uv_timer_t *timer)
     {
         return 0;
     }

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -228,3 +228,19 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 22
+    static char* uv_strerror_r(int error, char *buffer, size_t length)
+    {
+        strncpy(buffer, uv_strerror(error), length - 1);
+        buffer[length] = 0;
+        return buffer;
+    }
+
+    static char* uv_err_name_r(int error, char *buffer, size_t length)
+    {
+        strncpy(buffer, uv_err_name(error), length - 1);
+        buffer[length] = 0;
+        return buffer;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,31 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 9
+    #define UV_DISCONNECT 0
+
+    static int uv_os_tmpdir(char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+
+    typedef struct {
+        char *username;
+        long uid;
+        long gid;
+        char *shell;
+        char *homedir;
+    } uv_passwd_t;
+
+    static int uv_os_get_passwd(uv_passwd_t *passwd)
+    {
+        return ENOSYS;
+    }
+    static void uv_os_free_passwd(uv_passwd_t *passwd)
+    {
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 10
     static int uv_translate_sys_error(int sys_error)
     {

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -19,12 +19,18 @@
     static int uv_tcp_init_ex(
         uv_loop_t *loop, uv_tcp_t *tcp, unsigned int flags)
     {
+        if (flags != 0)
+            return ENOSYS;
+
         return uv_tcp_init(loop, tcp);
     }
 
     static int uv_udp_init_ex(
         uv_loop_t *loop, uv_udp_t *udp, unsigned int flags)
     {
+        if (flags & 0xFF != 0)
+            return ENOSYS;
+
         return uv_udp_init(loop, udp);
     }
 #endif
@@ -83,7 +89,7 @@
 
     static uv_os_fd_t uv_get_osfhandle(int fd)
     {
-        return fd;
+        return (uv_os_fd_t)-1;
     }
 
     static int uv_os_getenv(const char *name, char *buffer, size_t *size)
@@ -265,7 +271,7 @@
     typedef int uv_pid_t;
     static uv_pid_t uv_os_getppid()
     {
-        return 0;
+        return (uv_pid_t)-1;
     }
 
     static int uv_if_indextoname(
@@ -283,7 +289,7 @@
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 18
     static uv_pid_t uv_os_getpid()
     {
-        return 0;
+        return (uv_pid_t)-1;
     }
 #endif
 
@@ -374,14 +380,14 @@
     static char* uv_strerror_r(int error, char *buffer, size_t length)
     {
         strncpy(buffer, uv_strerror(error), length - 1);
-        buffer[length] = 0;
+        buffer[length - 1] = 0;
         return buffer;
     }
 
     static char* uv_err_name_r(int error, char *buffer, size_t length)
     {
         strncpy(buffer, uv_err_name(error), length - 1);
-        buffer[length] = 0;
+        buffer[length - 1] = 0;
         return buffer;
     }
 #endif
@@ -389,7 +395,7 @@
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 23
     static int uv_open_osfhandle(uv_os_fd_t os_fd)
     {
-        return (int)os_fd;
+        return (int)-1;
     }
 
     static int uv_os_getpriority(uv_pid_t pid, int *priority)

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -256,3 +256,8 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 20
+    #define UV_FS_COPYFILE_FICLONE 0
+    #define UV_FS_COPYFILE_FICLONE_FORCE 0
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -48,3 +48,16 @@
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 35
     #define UV_UDP_MMSG_CHUNK 0
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 34
+    static int uv_fs_mkstemp(
+        uv_loop_t *loop, uv_fs_t *request, const char *template,
+        uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    static void uv_sleep(unsigned int msec)
+    {
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -44,3 +44,7 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 35
+    #define UV_UDP_MMSG_CHUNK 0
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,42 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 12
+    static int uv_loop_fork(uv_loop_t* loop)
+    {
+        return ENOSYS;
+    }
+
+    static int uv_signal_start_oneshot(
+        uv_signal_t *signal, uv_signal_cb callback, int number)
+    {
+        return ENOSYS;
+    }
+
+    static uv_os_fd_t uv_get_osfhandle(int fd)
+    {
+        return fd;
+    }
+
+    static int uv_os_getenv(const char *name, char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+    static int uv_os_setenv(const char *name, const char *value)
+    {
+        return ENOSYS;
+    }
+    static int uv_os_unsetenv(const char *name)
+    {
+        return ENOSYS;
+    }
+
+    static int uv_os_gethostname(char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 14
     #define UV_PRIORITIZED 0
 

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -11,3 +11,17 @@
         return 0;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 39
+    #define UV_METRICS_IDLE_TIME 0
+
+    static uint64_t uv_metrics_idle_time(uv_loop_t *loop)
+    {
+        return 0;
+    }
+
+    static int uv_udp_using_recvmmsg(uv_udp_t *udp)
+    {
+        return 0;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -25,3 +25,9 @@
         return 0;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 38
+    static void uv_library_shutdown()
+    {
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -207,3 +207,8 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 24
+    #define UV_PROCESS_WINDOWS_HIDE_CONSOLE 0
+    #define UV_PROCESS_WINDOWS_HIDE_GUI 0
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -31,3 +31,7 @@
     {
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 37
+    #define UV_UDP_RECVMMSG 0
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -35,3 +35,12 @@
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 37
     #define UV_UDP_RECVMMSG 0
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 36
+    static int uv_fs_lutime(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, double atime,
+        double mtime, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -160,3 +160,15 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 27
+    static int uv_udp_connect(uv_udp_t *udp, const struct sockaddr *addr)
+    {
+        return ENOSYS;
+    }
+    static int uv_udp_getpeername(
+        const uv_udp_t *udp, struct sockaddr *name, int *namelen)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -128,3 +128,10 @@
     {
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 29
+    static uint64_t uv_get_constrained_memory()
+    {
+        return 0;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -61,3 +61,24 @@
     {
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 33
+    typedef int uv_random_t;
+    typedef void (*uv_random_cb)(
+        uv_random_t *request, int status, void* buffer, size_t length);
+    static int uv_random(
+        uv_loop_t *loop, uv_random_t *request, void *buffer, size_t length,
+        unsigned int flags, uv_random_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    typedef enum {UV_TTY_SUPPORTED, UV_TTY_UNSUPPORTED} uv_tty_vtermstate_t;
+    static void uv_tty_set_vterm_state(uv_tty_vtermstate_t state)
+    {
+    }
+    static int uv_tty_get_vterm_state(uv_tty_vtermstate_t *state)
+    {
+        return ENOTSUP;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -172,3 +172,25 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 26
+    typedef struct {
+        enum {
+            UV_THREAD_NO_FLAGS = 0x00,
+            UV_THREAD_HAS_STACK_SIZE = 0x01
+        } flags;
+        size_t stack_size;
+    } uv_thread_options_t;
+    static int uv_thread_create_ex(
+        uv_thread_t *id, const uv_thread_options_t *options, uv_thread_cb entry,
+        void* argument)
+    {
+        return uv_thread_create(id, entry, argument);
+    }
+
+    #ifdef MAXHOSTNAMELEN
+        #define UV_MAXHOSTNAMESIZE (MAXHOSTNAMELEN + 1)
+    #else
+        #define UV_MAXHOSTNAMESIZE 256
+    #endif
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,18 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 14
+    #define UV_PRIORITIZED 0
+
+    #define UV_FS_COPYFILE_EXCL 0
+    static int uv_fs_copyfile(
+        uv_loop_t *loop, uv_fs_t *request, const char *path,
+        const char *new_path, int flags, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 15
     static int uv_mutex_init_recursive(uv_mutex_t *mutex)
     {

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -194,3 +194,16 @@
         #define UV_MAXHOSTNAMESIZE 256
     #endif
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 25
+    typedef struct {
+        char sysname[256];
+        char release[256];
+        char version[256];
+        char machine[256];
+    } uv_utsname_t;
+    static int uv_os_uname(uv_utsname_t *buffer)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -99,3 +99,32 @@
         return ENOSYS;
     }
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 31
+    #define UV_FS_O_FILEMAP 0
+
+    typedef struct {
+        uint64_t f_type;
+        uint64_t f_bsize;
+        uint64_t f_blocks;
+        uint64_t f_bfree;
+        uint64_t f_bavail;
+        uint64_t f_files;
+        uint64_t f_ffree;
+        uint64_t f_spare[4];
+    } uv_statfs_t;
+    static int uv_fs_statfs(
+        uv_loop_t *loop, uv_fs_t *request, const char* path, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+
+    typedef struct {char *name; char *value;} uv_env_item_t;
+    static int uv_os_environ(uv_env_item_t **items, int *count)
+    {
+        return ENOSYS;
+    }
+    static void uv_os_free_environ(uv_env_item_t *items, int count)
+    {
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,162 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 16
+    #define UV_ENOTTY 0x24242424
+
+    // UV_FS_O_* flag definitions directly taken from uv/unix.h and uv/win.h as
+    // of libuv 1.41.0.
+    #if defined(_WIN32)
+        #define UV_FS_O_APPEND _O_APPEND
+        #define UV_FS_O_CREAT _O_CREAT
+        #define UV_FS_O_DIRECT 0x02000000
+        #define UV_FS_O_DSYNC 0x04000000
+        #define UV_FS_O_EXCL _O_EXCL
+        #define UV_FS_O_EXLOCK 0x10000000
+        #define UV_FS_O_NOATIME 0
+        #define UV_FS_O_NOCTTY 0
+        #define UV_FS_O_NOFOLLOW 0
+        #define UV_FS_O_NONBLOCK 0
+        #define UV_FS_O_RANDOM _O_RANDOM
+        #define UV_FS_O_RDONLY _O_RDONLY
+        #define UV_FS_O_RDWR _O_RDWR
+        #define UV_FS_O_SEQUENTIAL _O_SEQUENTIAL
+        #define UV_FS_O_SHORT_LIVED _O_SHORT_LIVED
+        #define UV_FS_O_SYMLINK 0
+        #define UV_FS_O_SYNC 0x08000000
+        #define UV_FS_O_TEMPORARY _O_TEMPORARY
+        #define UV_FS_O_TRUNC _O_TRUNC
+        #define UV_FS_O_WRONLY _O_WRONLY
+    #else
+        #if defined(O_APPEND)
+            #define UV_FS_O_APPEND O_APPEND
+        #else
+            #define UV_FS_O_APPEND 0
+        #endif
+        #if defined(O_CREAT)
+            #define UV_FS_O_CREAT O_CREAT
+        #else
+            #define UV_FS_O_CREAT 0
+        #endif
+        #if defined(__linux__) && defined(__arm__)
+            #define UV_FS_O_DIRECT 0x10000
+        #elif defined(__linux__) && defined(__m68k__)
+            #define UV_FS_O_DIRECT 0x10000
+        #elif defined(__linux__) && defined(__mips__)
+            #define UV_FS_O_DIRECT 0x08000
+        #elif defined(__linux__) && defined(__powerpc__)
+            #define UV_FS_O_DIRECT 0x20000
+        #elif defined(__linux__) && defined(__s390x__)
+            #define UV_FS_O_DIRECT 0x04000
+        #elif defined(__linux__) && defined(__x86_64__)
+            #define UV_FS_O_DIRECT 0x04000
+        #elif defined(O_DIRECT)
+            #define UV_FS_O_DIRECT O_DIRECT
+        #else
+            #define UV_FS_O_DIRECT 0
+        #endif
+        #if defined(O_DSYNC)
+            #define UV_FS_O_DSYNC O_DSYNC
+        #else
+            #define UV_FS_O_DSYNC 0
+        #endif
+        #if defined(O_EXCL)
+            #define UV_FS_O_EXCL O_EXCL
+        #else
+            #define UV_FS_O_EXCL 0
+        #endif
+        #if defined(O_EXLOCK)
+            #define UV_FS_O_EXLOCK O_EXLOCK
+        #else
+            #define UV_FS_O_EXLOCK 0
+        #endif
+        #if defined(O_NOATIME)
+            #define UV_FS_O_NOATIME O_NOATIME
+        #else
+            #define UV_FS_O_NOATIME 0
+        #endif
+        #if defined(O_NOCTTY)
+            #define UV_FS_O_NOCTTY O_NOCTTY
+        #else
+            #define UV_FS_O_NOCTTY 0
+        #endif
+        #if defined(O_NOFOLLOW)
+            #define UV_FS_O_NOFOLLOW O_NOFOLLOW
+        #else
+            #define UV_FS_O_NOFOLLOW 0
+        #endif
+        #if defined(O_NONBLOCK)
+            #define UV_FS_O_NONBLOCK O_NONBLOCK
+        #else
+            #define UV_FS_O_NONBLOCK 0
+        #endif
+        #define UV_FS_O_RANDOM 0
+        #if defined(O_RDONLY)
+            #define UV_FS_O_RDONLY O_RDONLY
+        #else
+            #define UV_FS_O_RDONLY 0
+        #endif
+        #if defined(O_RDWR)
+            #define UV_FS_O_RDWR O_RDWR
+        #else
+            #define UV_FS_O_RDWR 0
+        #endif
+        #define UV_FS_O_SEQUENTIAL 0
+        #define UV_FS_O_SHORT_LIVED 0
+        #if defined(O_SYMLINK)
+            #define UV_FS_O_SYMLINK O_SYMLINK
+        #else
+            #define UV_FS_O_SYMLINK 0
+        #endif
+        #if defined(O_SYNC)
+            #define UV_FS_O_SYNC O_SYNC
+        #else
+            #define UV_FS_O_SYNC 0
+        #endif
+        #define UV_FS_O_TEMPORARY 0
+        #if defined(O_TRUNC)
+            #define UV_FS_O_TRUNC O_TRUNC
+        #else
+            #define UV_FS_O_TRUNC 0
+        #endif
+        #if defined(O_WRONLY)
+            #define UV_FS_O_WRONLY O_WRONLY
+        #else
+            #define UV_FS_O_WRONLY 0
+        #endif
+    #endif
+
+    #if defined(IF_NAMESIZE)
+        #define UV_IF_NAMESIZE (IF_NAMESIZE + 1)
+    #elif defined(IFNAMSIZ)
+        #define UV_IF_NAMESIZE (IFNAMSIZ + 1)
+    #else
+        #define UV_IF_NAMESIZE (16 + 1)
+    #endif
+
+    static int uv_pipe_chmod(uv_pipe_t *pipe, int flags)
+    {
+        return ENOSYS;
+    }
+
+    typedef int uv_pid_t;
+    static uv_pid_t uv_os_getppid()
+    {
+        return 0;
+    }
+
+    static int uv_if_indextoname(
+        unsigned int interface, char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+    static int uv_if_indextoiid(
+        unsigned int interface, char *buffer, size_t *size)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 18
     static uv_pid_t uv_os_getpid()
     {

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -212,3 +212,19 @@
     #define UV_PROCESS_WINDOWS_HIDE_CONSOLE 0
     #define UV_PROCESS_WINDOWS_HIDE_GUI 0
 #endif
+
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 23
+    static int uv_open_osfhandle(uv_os_fd_t os_fd)
+    {
+        return (int)os_fd;
+    }
+
+    static int uv_os_getpriority(uv_pid_t pid, int *priority)
+    {
+        return ENOSYS;
+    }
+    static int uv_os_setpriority(uv_pid_t pid, int priority)
+    {
+        return ENOSYS;
+    }
+#endif

--- a/src/c/shims.h
+++ b/src/c/shims.h
@@ -3,6 +3,14 @@
 
 
 
+#if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 8
+    static int uv_fs_realpath(
+        uv_loop_t *loop, uv_fs_t *request, const char *path, uv_fs_cb callback)
+    {
+        return ENOSYS;
+    }
+#endif
+
 #if UV_VERSION_MAJOR == 1 && UV_VERSION_MINOR < 9
     #define UV_DISCONNECT 0
 

--- a/src/dune
+++ b/src/dune
@@ -5,8 +5,8 @@
  (flags (:standard -w -49 -open Result)))
 
 (rule
- (targets feature.mli feature.ml)
+ (targets require.mli require.ml)
  (action
-  (run feature/detect_features.exe)))
+  (run feature/detect_features.exe require.ml 99)))
 
 (documentation)

--- a/src/dune
+++ b/src/dune
@@ -4,4 +4,9 @@
  (libraries luv.c result)
  (flags (:standard -w -49 -open Result)))
 
+(rule
+ (targets feature.mli feature.ml)
+ (action
+  (run feature/detect_features.exe)))
+
 (documentation)

--- a/src/env.mli
+++ b/src/env.mli
@@ -8,14 +8,22 @@ val getenv : string -> (string, Error.t) result
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_getenv}
     [uv_os_getenv]}. See {{:http://man7.org/linux/man-pages/man3/getenv.3p.html}
-    [getenv(3p)]}. *)
+    [getenv(3p)]}.
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_getenv)] *)
 
 val setenv : string -> value:string -> (unit, Error.t) result
 (** Sets an environment variable.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_setenv}
     [uv_os_setenv]}. See {{:http://man7.org/linux/man-pages/man3/setenv.3p.html}
-    [setenv(3p)]}. *)
+    [setenv(3p)]}.
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_getenv)] *)
 
 val unsetenv : string -> (unit, Error.t) result
 (** Unsets an environment variable.
@@ -23,11 +31,19 @@ val unsetenv : string -> (unit, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_unsetenv}
     [uv_os_unsetenv]}. See
     {{:http://man7.org/linux/man-pages/man3/unsetenv.3p.html}
-    [unsetenv(3p)]}. *)
+    [unsetenv(3p)]}.
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_getenv)] *)
 
 val environ : unit -> ((string * string) list, Error.t) result
 (** Retrieves all environment variables.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_environ}
     [uv_os_environ]}. See
-    {{:http://man7.org/linux/man-pages/man3/environ.3p.html} [environ(3p)]}. *)
+    {{:http://man7.org/linux/man-pages/man3/environ.3p.html} [environ(3p)]}.
+
+    Requires libuv 1.31.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_environ)] *)

--- a/src/error.mli
+++ b/src/error.mli
@@ -96,8 +96,8 @@ type t = [
     {{:http://man7.org/linux/man-pages/man3/errno.3.html#DESCRIPTION} Unix error
     codes}.
 
-    [`EFTYPE] is available since Luv 0.5.5 and libuv 1.16.0. [`ENOTTY] is
-    available since Luv 0.5.5 and libuv 1.21.0. *)
+    [`EFTYPE] is available since Luv 0.5.5 and libuv 1.21.0. [`ENOTTY] is
+    available since Luv 0.5.5 and libuv 1.16.0. *)
 
 val strerror : t -> string
 (** Returns the error message corresponding to the given error code.

--- a/src/error.mli
+++ b/src/error.mli
@@ -96,7 +96,8 @@ type t = [
     {{:http://man7.org/linux/man-pages/man3/errno.3.html#DESCRIPTION} Unix error
     codes}.
 
-    [`EFTYPE] and [`ENOTTY] are available since Luv 0.5.5 (libuv 1.39.0). *)
+    [`EFTYPE] is available since Luv 0.5.5 and libuv 1.16.0. [`ENOTTY] is
+    available since Luv 0.5.5 and libuv 1.21.0. *)
 
 val strerror : t -> string
 (** Returns the error message corresponding to the given error code.

--- a/src/error.mli
+++ b/src/error.mli
@@ -103,13 +103,19 @@ val strerror : t -> string
 (** Returns the error message corresponding to the given error code.
 
     Binds {{:http://docs.libuv.org/en/v1.x/errors.html#c.uv_strerror_r}
-    [uv_strerror_r]}. *)
+    [uv_strerror_r]}.
+
+    If you are using libuv 1.21.0 or earlier, [Luv.Error.strerror `UNKNOWN]
+    slowly leaks memory. *)
 
 val err_name : t -> string
 (** Returns the name of the given error code.
 
     Binds {{:http://docs.libuv.org/en/v1.x/errors.html#c.uv_err_name_r}
-    [uv_err_name_r]}. *)
+    [uv_err_name_r]}.
+
+    If you are using libuv 1.21.0 or earlier, [Luv.Error.err_name `UNKNOWN]
+    slowly leaks memory. *)
 
 val translate_sys_error : int -> t
 (** Converts a system error code to a libuv error code.

--- a/src/error.mli
+++ b/src/error.mli
@@ -96,8 +96,17 @@ type t = [
     {{:http://man7.org/linux/man-pages/man3/errno.3.html#DESCRIPTION} Unix error
     codes}.
 
-    [`EFTYPE] is available since Luv 0.5.5 and libuv 1.21.0. [`ENOTTY] is
-    available since Luv 0.5.5 and libuv 1.16.0. *)
+    [`EFTYPE] is available since Luv 0.5.5 and libuv 1.21.0.
+
+    [`ENOTTY] is available since Luv 0.5.5 and libuv 1.16.0.
+
+    [`EILSEQ] is available since libuv 1.32.0.
+
+    {{!Luv.Require} Feature checks}:
+
+    - [Luv.Require.(has eftype)]
+    - [Luv.Require.(has enotty)]
+    - [Luv.Require.(has eilseq)] *)
 
 val strerror : t -> string
 (** Returns the error message corresponding to the given error code.
@@ -121,7 +130,11 @@ val translate_sys_error : int -> t
 (** Converts a system error code to a libuv error code.
 
     Binds {{:http://docs.libuv.org/en/v1.x/errors.html#c.uv_translate_sys_error}
-    [uv_translate_sys_error]}. *)
+    [uv_translate_sys_error]}.
+
+    Requires libuv 1.10.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has translate_sys_error)] *)
 
 val set_on_unhandled_exception : (exn -> unit) -> unit
 (** If user code terminates a callback by raising an exception, the exception

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -186,6 +186,8 @@ let () =
   bool "os_getenv" (version >= 12);
   bool "os_gethostname" (version >= 12);
 
+  bool "translate_sys_error" (version >= 10);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -120,6 +120,8 @@ let () =
 
   bool "library_shutdown" (version >= 38);
 
+  bool "udp_recvmmsg" (version >= 37);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -194,6 +194,9 @@ let () =
 
   bool "fs_realpath" (version >= 8);
 
+  bool "tcp_init_ex" (version >= 7);
+  bool "udp_init_ex" (version >= 7);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -132,6 +132,10 @@ let () =
   bool "random" (version >= 33);
   bool "tty_vterm_state" (version >= 33);
 
+  bool "eilseq" (version >= 32);
+  bool "tcp_close_reset" (version >= 32);
+  bool "udp_set_source_membership" (version >= 32);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -161,6 +161,10 @@ let () =
   bool "strerror_r" (version >= 22);
   bool "err_name_r" (version >= 22);
 
+  bool "eftype" (version >= 21);
+  bool "overlapped_pipe" (version >= 21);
+  bool "fs_lchown" (version >= 21);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -197,6 +197,8 @@ let () =
   bool "tcp_init_ex" (version >= 7);
   bool "udp_init_ex" (version >= 7);
 
+  bool "os_homedir" (version >= 6);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -118,6 +118,8 @@ let () =
   bool "metrics_idle_time" (version >= 39);
   bool "udp_using_recvmmsg" (version >= 39);
 
+  bool "library_shutdown" (version >= 38);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -115,6 +115,9 @@ let () =
   bool "udp_mmsg_free" (version >= 40);
   bool "timer_get_due_in" (version >= 40);
 
+  bool "metrics_idle_time" (version >= 39);
+  bool "udp_using_recvmmsg" (version >= 39);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -1,0 +1,120 @@
+(* This file is part of Luv, released under the MIT license. See LICENSE.md for
+   details, or visit https://github.com/aantron/luv/blob/master/LICENSE.md. *)
+
+
+
+let ground_numbers max_int buffer =
+  let p fmt = Printf.bprintf buffer fmt in
+  p "type 'p s\n";
+  p "\n";
+  p "type __0\n";
+  for i = 0 to max_int - 1 do
+    p "type __%i = __%i s\n" (i + 1) i
+  done;
+  p "type __inf = __%i\n" max_int
+
+let unification_numbers max_int buffer =
+  let p fmt = Printf.bprintf buffer fmt in
+  p "type 'u _0 = 'u\n";
+  for i = 0 to max_int - 1 do
+    p "type 'u _%i = 'u _%i s\n" (i + 1) i
+  done
+
+(* TODO Allow custom docs at the top of the .mli. *)
+(* TODO Docs for the visible values. *)
+let fixed_mli max_int buffer =
+  let p fmt = Printf.bprintf buffer fmt in
+  p "(**/*)\n";
+  p "\n";
+  ground_numbers max_int buffer;
+  p "\n";
+  unification_numbers max_int buffer;
+  p "\n";
+  p "type 'compile_time_value number\n";
+  p "\n";
+  for i = 0 to max_int do
+    p "val _%i : 'u _%i number\n" i i
+  done;
+  p "%s" {|
+type _true
+type _false
+
+(**/*)
+
+type ('run_time_value, 'compile_time_value) feature
+
+val run_time_check : ('run_time_value, _) feature -> 'run_time_value
+
+val at_least :
+  (_, 'compile_time_value) feature -> 'compile_time_value number -> unit
+val (>=) :
+  (_, 'compile_time_value) feature -> 'compile_time_value number -> unit
+val present :
+  (_, _true) feature -> unit
+|}
+
+let fixed_ml max_int buffer =
+  let p fmt = Printf.bprintf buffer fmt in
+  ground_numbers max_int buffer;
+  p "\n";
+  unification_numbers max_int buffer;
+  p "\n";
+  p "type 'compile_time_value number = unit\n";
+  p "\n";
+  for i = 0 to max_int do
+    p "let _%i = ()\n" i
+  done;
+    p "%s" {|
+type _true
+type _false
+
+type ('run_time_value, 'compile_time_value) feature = 'run_time_value
+
+let run_time_check feature =
+  feature
+
+let at_least _ _ =
+  ()
+
+let (>=) _ _ =
+  ()
+
+let present _ =
+  ()
+|}
+
+(* TODO Allow docstrings. *)
+let int (mli, ml) name value =
+  Printf.bprintf mli "\nval %s : (int, __%i) feature\n" name value;
+  Printf.bprintf ml "\nlet %s = %i\n" name value
+
+let bool (mli, ml) name value =
+  Printf.bprintf mli "\nval %s : (bool, _%b) feature\n" name value;
+  Printf.bprintf ml "\nlet %s = %b\n" name value
+
+let () =
+  let mli = "feature.mli" in
+  let ml = "feature.ml" in
+  let max_int = 99 in
+
+  let mli_buffer = Buffer.create 4096 in
+  fixed_mli max_int mli_buffer;
+
+  let ml_buffer = Buffer.create 4096 in
+  fixed_ml max_int ml_buffer;
+
+  let context = mli_buffer, ml_buffer in
+  let int = int context in
+  let _bool = bool context in
+
+  let version = Luv_c_types.Version.minor in
+
+  int "libuv1" version;
+
+  let mli_channel = open_out mli in
+  Buffer.contents mli_buffer |> output_string mli_channel;
+  close_out_noerr mli_channel;
+
+  let ml_channel = open_out ml in
+  Buffer.contents ml_buffer |> output_string ml_channel;
+  close_out_noerr ml_channel

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -175,6 +175,8 @@ let () =
   bool "if_indextoname" (version >= 16);
   bool "if_indextoiid" (version >= 16);
 
+  bool "mutex_init_recursive" (version >= 15);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -167,6 +167,8 @@ let () =
 
   bool "fs_copyfile_ficlone" (version >= 20);
 
+  bool "os_getpid" (version >= 18);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -124,6 +124,8 @@ let () =
 
   bool "fs_lutime" (version >= 36);
 
+  bool "udp_mmsg_chunk" (version >= 35);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -192,6 +192,8 @@ let () =
   bool "os_tmpdir" (version >= 9);
   bool "os_get_passwd" (version >= 9);
 
+  bool "fs_realpath" (version >= 8);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -169,6 +169,12 @@ let () =
 
   bool "os_getpid" (version >= 18);
 
+  bool "enotty" (version >= 16);
+  bool "pipe_chmod" (version >= 16);
+  bool "os_getppid" (version >= 16);
+  bool "if_indextoname" (version >= 16);
+  bool "if_indextoiid" (version >= 16);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -188,6 +188,10 @@ let () =
 
   bool "translate_sys_error" (version >= 10);
 
+  bool "disconnect" (version >= 9);
+  bool "os_tmpdir" (version >= 9);
+  bool "os_get_passwd" (version >= 9);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -180,6 +180,12 @@ let () =
   bool "prioritized" (version >= 14);
   bool "fs_copyfile" (version >= 14);
 
+  bool "loop_fork" (version >= 12);
+  bool "signal_start_oneshot" (version >= 12);
+  bool "get_osfhandle" (version >= 12);
+  bool "os_getenv" (version >= 12);
+  bool "os_gethostname" (version >= 12);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -158,6 +158,9 @@ let () =
   bool "open_osfhandle" (version >= 23);
   bool "uv_os_priority" (version >= 23);
 
+  bool "strerror_r" (version >= 22);
+  bool "err_name_r" (version >= 22);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -150,6 +150,8 @@ let () =
   bool "thread_stack_size" (version >= 26);
   bool "maxhostnamesize" (version >= 26);
 
+  bool "os_uname" (version >= 25);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -126,6 +126,9 @@ let () =
 
   bool "udp_mmsg_chunk" (version >= 35);
 
+  bool "fs_mkstemp" (version >= 34);
+  bool "sleep" (version >= 34);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -105,11 +105,15 @@ let () =
 
   let context = mli_buffer, ml_buffer in
   let int = int context in
-  let _bool = bool context in
+  let bool = bool context in
 
   let version = Luv_c_types.Version.minor in
 
   int "libuv1" version;
+  int "luv05" 7;
+
+  bool "udp_mmsg_free" (version >= 40);
+  bool "timer_get_due_in" (version >= 40);
 
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -3,6 +3,87 @@
 
 
 
+let module_doc = {|(** Feature checks.
+
+    If you installed Luv in the usual way, through either opam or esy, you can
+    ignore this module completely. In this case, Luv internally installed a
+    vendored libuv of a recent version, and you have all the latest APIs
+    available — whatever is exposed by your version of Luv {e is} actually
+    implemented by libuv.
+
+    However, if you installed Luv through a system package manager, or tweaked
+    your Luv installation so that it links to a system or other external libuv,
+    that external libuv might be of a considerably older version than Luv. Not
+    all features normally exposed by Luv might actually be available.
+
+    In that case, this module provides a bunch of useful feature checks, so that
+    you can control the behavior of your downstream project and/or prevent its
+    compilation with too old a libuv. *)|}
+
+let type_feature_doc = {|(** A value of type ['a feature] is physically either a
+    [bool] or an [int].
+
+    The [constraint] notation can be ignored. It's part of this module's
+    internal type machinery for implementing compile-time feature checking.
+
+    Specific features (see below) have types like [_40 feature] or [_true
+    feature]. The first is an [int] feature whose run-time value is [40], and
+    the second is a [bool] feature whose run-time value is [true].
+
+    As you can see, the run-time value can be seen from the type, and therefore
+    from the docs, at a glance. So, you can quickly find out what your libuv
+    supports by generating the docs for your Luv installation and looking at
+    this module.
+
+    Of course, if you installed Luv through opam/esy and are using its vendored
+    libuv, the [int] features will simply be the corresponding libuv version,
+    and all the [bool] features will be [_true]. *)|}
+
+let get_doc = {|(** Returns the value of a feature at run time — in the ordinary
+    way. Examples:
+
+    - [Luv.Require.(get luv05)] returns [7] at the time of this writing — the
+      current patch version of Luv (0.5.7).
+    - [Luv.Require.(get random)] returns [true] if Luv was linked with a libuv
+      late enough that it supports [uv_random] (1.33.0 or higher). *)|}
+
+let at_least_doc = {|(** Triggers a compile-time check of an [int] feature.
+
+    For example, take [Luv.Require.(libuv1 >= _33)].
+
+    If the linked libuv has version 1.33.0 or higher, this check compiles. The
+    compiled check then does nothing at run time — it is zero-cost.
+
+    If libuv has version less than 1.33.0, compilation of this expression
+    triggers a type error. If that is too severe, you can relax to a run-time
+    check by doing [Luv.Require.(get libuv1) >= 33] instead.
+
+    The compile-time numbers [_0] — [_99] are defined for use in with
+    [Luv.Require.(>=)]. They are hidden from this documentation to reduce visual
+    noise.
+
+    These compile-time checks are modular in the sense that you can spread them
+    throughout your project, locally where various features of libuv are being
+    used, so that you don't have to do a survey of all your code in order to
+    figure out the overall minimum libuv version. During build, your project
+    will compile only if all the checks in its modules pass. They will then be
+    optimized away. *)|}
+
+let has_doc = {|(** Triggers a compile-time check of a [bool] feature.
+
+    For example, take [Luv.Require.(has random)].
+
+    If the linked libuv has [uv_random], this check compiles, and is fully
+    optimized away.
+
+    If libuv lacks [uv_random], compilation of this check triggers a type error.
+    The check can be relaxed to run time by doing [Luv.Require.(get random)]
+    instead.
+
+    As with {!Luv.Require.(>=)}, you can insert these checks throughout your
+    program, locally near where you use libuv features. The project will compile
+    only if all the checks pass. *)|}
+
 let ground_numbers max_int buffer =
   let p fmt = Printf.bprintf buffer fmt in
   p "type 'p s\n";
@@ -31,6 +112,7 @@ let unification_numbers max_int buffer =
 (* TODO Docs for the visible values. *)
 let fixed_mli max_int buffer =
   let p fmt = Printf.bprintf buffer fmt in
+  p "%s\n\n" module_doc;
   p "(**/**)\n";
   p "\n";
   ground_numbers max_int buffer;
@@ -44,7 +126,7 @@ let fixed_mli max_int buffer =
   for i = 0 to max_int do
     p "val _%i : 'u __%i number\n" i i
   done;
-  p "%s" {|
+  p "%s" @@ {|
 type __true
 type __false
 
@@ -55,11 +137,19 @@ type _false = bool * __false
 
 type 'a feature
   constraint 'a = 'run_time * 'compile_time
+|}^ type_feature_doc ^{|
 
 val get : ('run_time * _) feature -> 'run_time
+|}^ get_doc ^{|
 
 val (>=) : (int * 'compile_time) feature -> 'compile_time number -> unit
+|}^ at_least_doc ^{|
+
 val has : _true feature -> unit
+|}^ has_doc ^{|
+
+(** {1 Features} *)
+
 |}
 
 let fixed_ml max_int buffer =
@@ -95,13 +185,18 @@ let has _ =
   ()
 |}
 
+let wrap_doc doc =
+  match doc with
+  | "" -> ""
+  | _ -> "(** " ^ doc ^ "*)\n"
+
 (* TODO Allow docstrings. *)
-let int (mli, ml) name value =
-  Printf.bprintf mli "\nval %s : _%i feature\n" name value;
+let int (mli, ml) ?(doc = "") name value =
+  Printf.bprintf mli "\nval %s : _%i feature\n%s" name value (wrap_doc doc);
   Printf.bprintf ml "\nlet %s = %i\n" name value
 
-let bool (mli, ml) name value =
-  Printf.bprintf mli "\nval %s : _%b feature\n" name value;
+let bool (mli, ml) ?(doc = "") name value =
+  Printf.bprintf mli "\nval %s : _%b feature\n%s" name value (wrap_doc doc);
   Printf.bprintf ml "\nlet %s = %b\n" name value
 
 let () =
@@ -120,97 +215,68 @@ let () =
   let context = mli_buffer, ml_buffer in
   let int = int context in
 
-  int "libuv1" version;
-  int "luv05" 7;
+  int "libuv1" version ~doc:"libuv minor version in the 1.x series.";
+  int "luv05" 7 ~doc:"Luv patch version in the 0.5.x series.";
 
   let needs min name = bool context name (version >= min) in
 
-  needs 40 "udp_mmsg_free";
-  needs 40 "timer_get_due_in";
-
-  needs 39 "metrics_idle_time";
-  needs 39 "udp_using_recvmmsg";
-
-  needs 38 "library_shutdown";
-
-  needs 37 "udp_recvmmsg";
-
-  needs 36 "fs_lutime";
-
-  needs 35 "udp_mmsg_chunk";
-
-  needs 34 "fs_mkstemp";
-  needs 34 "sleep";
-
-  needs 33 "random";
-  needs 33 "tty_vterm_state";
-
-  needs 32 "eilseq";
-  needs 32 "tcp_close_reset";
-  needs 32 "udp_set_source_membership";
-
-  needs 31 "fs_o_filemap";
-  needs 31 "fs_statfs";
-  needs 31 "os_environ";
-
-  needs 29 "get_constrained_memory";
-
-  needs 28 "gettimeofday";
-  needs 28 "readdir";
-
-  needs 27 "udp_connect";
-
-  needs 26 "thread_stack_size";
-  needs 26 "maxhostnamesize";
-
-  needs 25 "os_uname";
-
-  needs 24 "process_windows_hide_console";
-  needs 24 "process_windows_hide_gui";
-
-  needs 23 "open_osfhandle";
-  needs 23 "uv_os_priority";
-
-  needs 22 "strerror_r";
-  needs 22 "err_name_r";
-
+  needs  9 "disconnect";
   needs 21 "eftype";
-  needs 21 "overlapped_pipe";
-  needs 21 "fs_lchown";
-
-  needs 20 "fs_copyfile_ficlone";
-
-  needs 18 "os_getpid";
-
+  needs 32 "eilseq";
   needs 16 "enotty";
-  needs 16 "pipe_chmod";
-  needs 16 "os_getppid";
-  needs 16 "if_indextoname";
-  needs 16 "if_indextoiid";
-
-  needs 15 "mutex_init_recursive";
-
-  needs 14 "prioritized";
+  needs 22 "err_name_r";
   needs 14 "fs_copyfile";
-
-  needs 12 "loop_fork";
-  needs 12 "signal_start_oneshot";
+  needs 20 "fs_copyfile_ficlone";
+  needs 36 "fs_lutime";
+  needs 21 "fs_lchown";
+  needs 34 "fs_mkstemp";
+  needs 31 "fs_o_filemap";
+  needs  8 "fs_realpath";
+  needs 31 "fs_statfs";
+  needs 29 "get_constrained_memory";
   needs 12 "get_osfhandle";
+  needs 28 "gettimeofday";
+  needs 16 "if_indextoiid";
+  needs 16 "if_indextoname";
+  needs 38 "library_shutdown";
+  needs 12 "loop_fork";
+  needs 26 "maxhostnamesize";
+  needs 39 "metrics_idle_time";
+  needs 15 "mutex_init_recursive";
+  needs 23 "open_osfhandle";
+  needs 31 "os_environ";
+  needs  6 "os_homedir";
+  needs  9 "os_get_passwd";
   needs 12 "os_getenv";
   needs 12 "os_gethostname";
-
-  needs 10 "translate_sys_error";
-
-  needs  9 "disconnect";
+  needs 18 "os_getpid";
+  needs 16 "os_getppid";
+  needs 23 "os_priority";
   needs  9 "os_tmpdir";
-  needs  9 "os_get_passwd";
-
-  needs  8 "fs_realpath";
-
+  needs 25 "os_uname";
+  needs 21 "overlapped_pipe";
+  needs 16 "pipe_chmod";
+  needs 14 "prioritized";
+  needs 24 "process_windows_hide_console";
+  needs 24 "process_windows_hide_gui";
+  needs 33 "random";
+  needs 28 "readdir";
+  needs 12 "signal_start_oneshot";
+  needs 34 "sleep";
+  needs 22 "strerror_r";
+  needs 32 "tcp_close_reset";
   needs  7 "tcp_init_ex";
+  needs 40 "timer_get_due_in";
+  needs 26 "thread_stack_size";
+  needs 10 "translate_sys_error";
+  needs 33 "tty_vterm_state";
+  needs 27 "udp_connect";
   needs  7 "udp_init_ex";
-
-  needs  6 "os_homedir";
+  needs 35 "udp_mmsg_chunk";
+  needs 40 "udp_mmsg_free";
+  needs 37 "udp_recvmmsg";
+  needs 32 "udp_set_source_membership";
+  needs 39 "udp_using_recvmmsg";
 
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -5,6 +5,8 @@
 
 let module_doc = {|(** Feature checks.
 
+    {e You probably don't need these!}
+
     If you installed Luv in the usual way, through either opam or esy, you can
     ignore this module completely. In this case, Luv internally installed a
     vendored libuv of a recent version, and you have all the latest APIs
@@ -12,13 +14,16 @@ let module_doc = {|(** Feature checks.
     implemented by libuv.
 
     However, if you installed Luv through a system package manager, or tweaked
-    your Luv installation so that it links to a system or other external libuv,
-    that external libuv might be of a considerably older version than Luv. Not
-    all features normally exposed by Luv might actually be available.
+    your Luv installation so that it links to a system or other external libuv
+    — or if your users will do so — that external libuv might be of a
+    considerably older version than Luv expects. Not all features normally
+    exposed by Luv might actually be available.
 
-    In that case, this module provides a bunch of useful feature checks, so that
-    you can control the behavior of your downstream project and/or prevent its
-    compilation with too old a libuv. *)|}
+    For that case, this module provides a bunch of useful feature checks, so
+    that you can control the behavior of your downstream project and/or prevent
+    its compilation with too old a libuv.
+
+    This module itself is present since Luv 0.5.7. *)|}
 
 let type_feature_doc = {|(** A value of type ['a feature] is physically either a
     [bool] or an [int].
@@ -218,65 +223,67 @@ let () =
   int "libuv1" version ~doc:"libuv minor version in the 1.x series.";
   int "luv05" 7 ~doc:"Luv patch version in the 0.5.x series.";
 
-  let needs min name = bool context name (version >= min) in
+  let needs ?doc min name = bool context ?doc name (version >= min) in
 
-  needs  9 "disconnect";
-  needs 21 "eftype";
-  needs 32 "eilseq";
-  needs 16 "enotty";
-  needs 22 "err_name_r";
-  needs 14 "fs_copyfile";
-  needs 20 "fs_copyfile_ficlone";
-  needs 36 "fs_lutime";
-  needs 21 "fs_lchown";
-  needs 34 "fs_mkstemp";
-  needs 31 "fs_o_filemap";
-  needs  8 "fs_realpath";
-  needs 31 "fs_statfs";
-  needs 29 "get_constrained_memory";
-  needs 12 "get_osfhandle";
-  needs 28 "gettimeofday";
-  needs 16 "if_indextoiid";
-  needs 16 "if_indextoname";
-  needs 38 "library_shutdown";
-  needs 12 "loop_fork";
-  needs 26 "maxhostnamesize";
-  needs 39 "metrics_idle_time";
-  needs 15 "mutex_init_recursive";
-  needs 23 "open_osfhandle";
-  needs 31 "os_environ";
-  needs  6 "os_homedir";
-  needs  9 "os_get_passwd";
-  needs 12 "os_getenv";
-  needs 12 "os_gethostname";
-  needs 18 "os_getpid";
-  needs 16 "os_getppid";
-  needs 23 "os_priority";
-  needs  9 "os_tmpdir";
-  needs 25 "os_uname";
-  needs 21 "overlapped_pipe";
-  needs 16 "pipe_chmod";
-  needs 14 "prioritized";
-  needs 24 "process_windows_hide_console";
-  needs 24 "process_windows_hide_gui";
-  needs 33 "random";
-  needs 28 "readdir";
-  needs 12 "signal_start_oneshot";
-  needs 34 "sleep";
-  needs 22 "strerror_r";
-  needs 32 "tcp_close_reset";
-  needs  7 "tcp_init_ex";
-  needs 40 "timer_get_due_in";
-  needs 26 "thread_stack_size";
-  needs 10 "translate_sys_error";
-  needs 33 "tty_vterm_state";
-  needs 27 "udp_connect";
-  needs  7 "udp_init_ex";
-  needs 35 "udp_mmsg_chunk";
-  needs 40 "udp_mmsg_free";
-  needs 37 "udp_recvmmsg";
-  needs 32 "udp_set_source_membership";
-  needs 39 "udp_using_recvmmsg";
+  needs  9 "disconnect" ~doc:"See [`DISCONNECT] in {!Luv.Poll.Event.t}.";
+  needs 21 "eftype" ~doc:"See [`EFTYPE] in {!Luv.Error.t}.";
+  needs 32 "eilseq" ~doc:"See [`EILSEQ] in {!Luv.Error.t}.";
+  needs 16 "enotty" ~doc:"See [`ENOTTY] in {!Luv.Error.t}.";
+  needs 22 "err_name_r" ~doc:"See {!Luv.Error.err_name}.";
+  needs 14 "fs_copyfile" ~doc:"See {!Luv.File.copyfile}.";
+  needs 20 "fs_copyfile_ficlone" ~doc:"See signature of {!Luv.File.copyfile}.";
+  needs 36 "fs_lutime" ~doc:"See {!Luv.File.lutime}.";
+  needs 21 "fs_lchown" ~doc:"See {!Luv.File.lchown}.";
+  needs 34 "fs_mkstemp" ~doc:"See {!Luv.File.mkstemp}.";
+  needs 31 "fs_o_filemap" ~doc:"See [`FILEMAP] {!Luv.File.Open_flag.t}.";
+  needs  8 "fs_realpath" ~doc:"See {!Luv.File.realpath}.";
+  needs 31 "fs_statfs" ~doc:"See {!Luv.File.statfs}.";
+  needs 29 "get_constrained_memory"
+    ~doc:"See {!Luv.Resource.constrained_memory}.";
+  needs 12 "get_osfhandle" ~doc:"See {!Luv.File.get_osfhandle}.";
+  needs 28 "gettimeofday" ~doc:"See {!Luv.Time.gettimeofday}.";
+  needs 16 "if_indextoiid" ~doc:"See {!Luv.Network.if_indextoiid}.";
+  needs 16 "if_indextoname" ~doc:"See {!Luv.Network.if_indextoname}.";
+  needs 38 "library_shutdown" ~doc:"See {!Luv.Loop.library_shutdown}.";
+  needs 12 "loop_fork" ~doc:"See {!Luv.Loop.fork}.";
+  needs 26 "maxhostnamesize" ~doc:"Used internally.";
+  needs 39 "metrics_idle_time" ~doc:"See {!Luv.Metrics.idle_time}.";
+  needs 15 "mutex_init_recursive" ~doc:"See {!Luv.Mutex.init}.";
+  needs 23 "open_osfhandle" ~doc:"See {!Luv.File.open_osfhandle}.";
+  needs 31 "os_environ" ~doc:"See {!Luv.Env.environ}.";
+  needs  6 "os_homedir" ~doc:"See {!Luv.Path.homedir}.";
+  needs  9 "os_get_passwd" ~doc:"See {!Luv.Passwd.get_passwd}.";
+  needs 12 "os_getenv" ~doc:"See {!Luv.Env.getenv}.";
+  needs 12 "os_gethostname" ~doc:"See {!Luv.Network.gethostname}.";
+  needs 18 "os_getpid" ~doc:"See {!Luv.Pid.getpid}.";
+  needs 16 "os_getppid" ~doc:"See {!Luv.Pid.getppid}.";
+  needs 23 "os_priority" ~doc:"See {!Luv.Resource.setpriority}.";
+  needs  9 "os_tmpdir" ~doc:"See {!Luv.Path.tmpdir}.";
+  needs 25 "os_uname" ~doc:"See {!Luv.System_info.uname}.";
+  needs 21 "overlapped_pipe" ~doc:"See {!Luv.Process.to_parent_pipe}.";
+  needs 16 "pipe_chmod" ~doc:"See {!Luv.Pipe.chmod}.";
+  needs 14 "prioritized" ~doc:"See [`PRIORITIZED] in {!Luv.Poll.Event.t}.";
+  needs 24 "process_windows_hide_console" ~doc:"See {!Luv.Process.spawn}.";
+  needs 24 "process_windows_hide_gui" ~doc:"See {!Luv.Process.spawn}.";
+  needs 33 "random" ~doc:"See {!Luv.Random.random}.";
+  needs 28 "readdir" ~doc:"See {!Luv.File.readdir}.";
+  needs 12 "signal_start_oneshot" ~doc:"See {!Luv.Signal.start_oneshot}.";
+  needs 34 "sleep" ~doc:"See {!Luv.Time.sleep}.";
+  needs 22 "strerror_r" ~doc:"See {!Luv.Error.strerror}.";
+  needs 32 "tcp_close_reset" ~doc:"See {!Luv.TCP.close_reset}.";
+  needs  7 "tcp_init_ex" ~doc:"See {!Luv.TCP.init}.";
+  needs 40 "timer_get_due_in" ~doc:"See {!Luv.Timer.get_due_in}.";
+  needs 26 "thread_stack_size" ~doc:"See {!Luv.Thread.create}.";
+  needs 10 "translate_sys_error" ~doc:"See {!Luv.Error.translate_sys_error}.";
+  needs 33 "tty_vterm_state" ~doc:"See {!Luv.TTY.set_vterm_state}.";
+  needs 27 "udp_connect" ~doc:"See {!Luv.UDP.Connected}.";
+  needs  7 "udp_init_ex" ~doc:"See {!Luv.UDP.init}.";
+  needs 35 "udp_mmsg_chunk" ~doc:"See [`MMSG_CHUNK] in {!Luv.UDP.Recv_flag.t}.";
+  needs 40 "udp_mmsg_free" ~doc:"See [`MMSG_FREE] in {!Luv.UDP.Recv_flag.t}.";
+  needs 37 "udp_recvmmsg" ~doc:"See {!Luv.UDP.init}.";
+  needs 32 "udp_set_source_membership"
+    ~doc:"See {!Luv.UDP.set_source_membership}.";
+  needs 39 "udp_using_recvmmsg" ~doc:"See {!Luv.UDP.using_recvmmsg}.";
 
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -129,6 +129,9 @@ let () =
   bool "fs_mkstemp" (version >= 34);
   bool "sleep" (version >= 34);
 
+  bool "random" (version >= 33);
+  bool "tty_vterm_state" (version >= 33);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -140,6 +140,8 @@ let () =
   bool "fs_statfs" (version >= 31);
   bool "os_environ" (version >= 31);
 
+  bool "get_constrained_memory" (version >= 29);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -122,6 +122,8 @@ let () =
 
   bool "udp_recvmmsg" (version >= 37);
 
+  bool "fs_lutime" (version >= 36);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -147,6 +147,9 @@ let () =
 
   bool "udp_connect" (version >= 27);
 
+  bool "thread_stack_size" (version >= 26);
+  bool "maxhostnamesize" (version >= 26);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -165,6 +165,8 @@ let () =
   bool "overlapped_pipe" (version >= 21);
   bool "fs_lchown" (version >= 21);
 
+  bool "fs_copyfile_ficlone" (version >= 20);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -145,6 +145,8 @@ let () =
   bool "gettimeofday" (version >= 28);
   bool "readdir" (version >= 28);
 
+  bool "udp_connect" (version >= 27);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -152,6 +152,9 @@ let () =
 
   bool "os_uname" (version >= 25);
 
+  bool "process_windows_hide_console" (version >= 24);
+  bool "process_windows_hide_gui" (version >= 24);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -155,6 +155,9 @@ let () =
   bool "process_windows_hide_console" (version >= 24);
   bool "process_windows_hide_gui" (version >= 24);
 
+  bool "open_osfhandle" (version >= 23);
+  bool "uv_os_priority" (version >= 23);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -142,6 +142,9 @@ let () =
 
   bool "get_constrained_memory" (version >= 29);
 
+  bool "gettimeofday" (version >= 28);
+  bool "readdir" (version >= 28);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -177,6 +177,9 @@ let () =
 
   bool "mutex_init_recursive" (version >= 15);
 
+  bool "prioritized" (version >= 14);
+  bool "fs_copyfile" (version >= 14);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/detect_features.ml
+++ b/src/feature/detect_features.ml
@@ -136,6 +136,10 @@ let () =
   bool "tcp_close_reset" (version >= 32);
   bool "udp_set_source_membership" (version >= 32);
 
+  bool "fs_o_filemap" (version >= 31);
+  bool "fs_statfs" (version >= 31);
+  bool "os_environ" (version >= 31);
+
   let mli_channel = open_out mli in
   Buffer.contents mli_buffer |> output_string mli_channel;
   close_out_noerr mli_channel;

--- a/src/feature/dune
+++ b/src/feature/dune
@@ -1,0 +1,3 @@
+(executable
+ (name detect_features)
+ (libraries luv.c))

--- a/src/file.mli
+++ b/src/file.mli
@@ -143,6 +143,9 @@ sig
     | `SYMLINK
     | `SYNC
   ]
+  (** [`FILEMAP] requires libuv 1.31.0.
+
+      {{!Luv.Require} Feature check}: [Luv.Require.(has fs_o_filemap)] *)
 end
 
 (** {{!Luv.File.Mode} Permissions bits}. *)
@@ -331,7 +334,11 @@ val mkstemp :
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_mkstemp}
     [uv_fs_mkstemp]}. See
     {{:http://man7.org/linux/man-pages/man3/mkdtemp.3p.html} [mkstemp(3p)]}. The
-    synchronous version is {!Luv.File.Sync.mkstemp}. *)
+    synchronous version is {!Luv.File.Sync.mkstemp}.
+
+    Requires libuv 1.34.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_mkstemp)] *)
 
 val mkdtemp :
   ?loop:Loop.t ->
@@ -421,7 +428,11 @@ val opendir :
     {{:http://man7.org/linux/man-pages/man3/fdopendir.3p.html} [opendir(3p)]}.
     The synchronous version is {!Luv.File.Sync.opendir}.
 
-    The directory must later be closed with {!Luv.File.closedir}. *)
+    The directory must later be closed with {!Luv.File.closedir}.
+
+    Requires libuv 1.28.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_readdir)] *)
 
 val closedir :
   ?loop:Loop.t ->
@@ -434,7 +445,11 @@ val closedir :
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_closedir}
     [uv_fs_closedir]}. See
     {{:http://man7.org/linux/man-pages/man3/closedir.3p.html} [closedir(3p)]}.
-    The synchronous version is {!Luv.File.Sync.closedir}. *)
+    The synchronous version is {!Luv.File.Sync.closedir}.
+
+    Requires libuv 1.28.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_readdir)] *)
 
 val readdir :
   ?loop:Loop.t ->
@@ -448,7 +463,11 @@ val readdir :
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_readdir}
     [uv_fs_readdir]}. See
     {{:http://man7.org/linux/man-pages/man3/readdir.3p.html} [readdir(3p)]}. The
-    synchronous version is {!Luv.File.Sync.readdir}. *)
+    synchronous version is {!Luv.File.Sync.readdir}.
+
+    Requires libuv 1.28.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_readdir)] *)
 
 (** Abstract type of of directory scans. See {!Luv.File.scandir}. *)
 module Directory_scan :
@@ -587,7 +606,11 @@ val statfs :
 
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_statfs}
     [uv_fs_statfs]}. See {{:http://man7.org/linux/man-pages/man2/statfs.2.html}
-    [statfs(2)]}. The synchronous version is {!Luv.File.Sync.statfs}. *)
+    [statfs(2)]}. The synchronous version is {!Luv.File.Sync.statfs}.
+
+    Requires libuv 1.31.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_statfs)] *)
 
 
 
@@ -649,7 +672,17 @@ val copyfile :
 (** Copies the file at the given path to the path given by [~to_].
 
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_copyfile}
-    [uv_fs_copyfile]}. The synchronous version is {!Luv.File.Sync.copyfile}. *)
+    [uv_fs_copyfile]}. The synchronous version is {!Luv.File.Sync.copyfile}.
+
+    Requires libuv 1.14.0.
+
+    [?ficlone] and [?ficlone_force] have no effect if the libuv version is less
+    than 1.20.0.
+
+    {{!Luv.Require} Feature checks}:
+
+    - [Luv.Require.(has fs_copyfile)]
+    - [Luv.Require.(has fs_copyfile_ficlone)] *)
 
 val sendfile :
   ?loop:Loop.t ->
@@ -771,7 +804,9 @@ val lutime :
     [uv_fs_lutime]}. See {{:http://man7.org/linux/man-pages/man3/lutimes.3.html}
     [lutimes(3)]}. The synchronous version is {!Luv.File.Sync.lutime}.
 
-    @since Luv 0.5.2 (libuv 1.36.0). *)
+    Requires Luv 0.5.2 and libuv 1.36.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_lutime)] *)
 
 
 
@@ -833,7 +868,11 @@ val realpath :
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_realpath}
     [uv_fs_readpath]}. See
     {{:http://man7.org/linux/man-pages/man3/realpath.3p.html} [realpath(3p)]}.
-    The synchronous version is {!Luv.File.Sync.realpath}. *)
+    The synchronous version is {!Luv.File.Sync.realpath}.
+
+    Requires libuv 1.8.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_realpath)] *)
 
 
 
@@ -867,7 +906,11 @@ val lchown :
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_lchown}
     [uv_fs_lchown]}. See
     {{:http://man7.org/linux/man-pages/man3/lchown.3p.html} [lchown(3p)]}. The
-    synchronous version is {!Luv.File.Sync.lchown}. *)
+    synchronous version is {!Luv.File.Sync.lchown}.
+
+    Requires libuv 1.21.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has fs_lchown)] *)
 
 val fchown :
   ?loop:Loop.t ->
@@ -1091,7 +1134,11 @@ val get_osfhandle : t -> (Os_fd.Fd.t, Error.t) result
 
     On Unix-like systems, this passes the file descriptor through unchanged. On
     Windows, a {!Luv.File.t} is an C runtime library file descritpor. This
-    function converts it to a [HANDLE]. *)
+    function converts it to a [HANDLE].
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has get_osfhandle)] *)
 
 val open_osfhandle : Os_fd.Fd.t -> (t, Error.t) result
 (** Inverse of {!Luv.File.get_osfhandle}.
@@ -1099,7 +1146,11 @@ val open_osfhandle : Os_fd.Fd.t -> (t, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/fs.html#c.uv_open_osfhandle}
     [uv_open_osfhandle]}. See
     {{:https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle}
-    [_open_osfhandle]}. *)
+    [_open_osfhandle]}.
+
+    Requires libuv 1.23.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has open_osfhandle)] *)
 
 val to_int : t -> int
 (** Returns the integer representation of a {!Luv.File.t}.

--- a/src/loop.mli
+++ b/src/loop.mli
@@ -117,7 +117,11 @@ val fork : t -> (unit, Error.t) result
 (** Reinitializes libuv after a call to [fork(2)].
 
     Binds {{:http://docs.libuv.org/en/v1.x/loop.html#c.uv_loop_fork}
-    [uv_loop_fork]}. *)
+    [uv_loop_fork]}.
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has loop_fork)] *)
 
 val library_shutdown : unit -> unit
 (** Releases any state libuv is holding on to.
@@ -127,7 +131,9 @@ val library_shutdown : unit -> unit
 
     Note especially the warnings in the libuv documentation of this function.
 
-    @since Luv 0.5.3 (libuv 1.38.0) *)
+    Requiers Luv 0.5.3 and libuv 1.38.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has library_shutdown)] *)
 
 (**/**)
 

--- a/src/luv.ml
+++ b/src/luv.ml
@@ -64,4 +64,4 @@ module Env = Env
 module Time = Time
 module Random = Random
 module Metrics = Metrics
-module Feature = Feature
+module Require = Require

--- a/src/luv.ml
+++ b/src/luv.ml
@@ -64,3 +64,4 @@ module Env = Env
 module Time = Time
 module Random = Random
 module Metrics = Metrics
+module Feature = Feature

--- a/src/metrics.mli
+++ b/src/metrics.mli
@@ -17,4 +17,6 @@ val idle_time : Loop.t -> Unsigned.UInt64.t
     Binds {{:http://docs.libuv.org/en/v1.x/metrics.html#c.uv_metrics_idle_time}
     [uv_metrics_idle_time]}.
 
-    @since Luv 0.5.5 (libuv 1.39.0) *)
+    Requires Luv 0.5.5 and libuv 1.39.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has metrics_idle_time)] *)

--- a/src/mutex.mli
+++ b/src/mutex.mli
@@ -25,7 +25,11 @@ val init : ?recursive:bool -> unit -> (t, Error.t) result
 
     If [?recursive] is set to [true], calls
     {{:http://docs.libuv.org/en/v1.x/threading.html#c.uv_mutex_init_recursive}
-    [uv_mutex_init_recursive]} instead. *)
+    [uv_mutex_init_recursive]} instead.
+
+    [?recursive] requires libuv 1.15.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has mutex_init_recursive)] *)
 
 val destroy : t -> unit
 (** Cleans up a mutex.

--- a/src/network.mli
+++ b/src/network.mli
@@ -30,11 +30,19 @@ val if_indextoname : int -> (string, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_if_indextoname}
     [uv_if_indextoname]}. See
     {{:http://man7.org/linux/man-pages/man3/if_indextoname.3p.html}
-    [if_indextoname(3p)]}. *)
+    [if_indextoname(3p)]}.
+
+    Requires libuv 1.16.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has if_indextoname)] *)
 
 val if_indextoiid : int -> (string, Error.t) result
 (** Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_if_indextoiid}
-    [uv_if_indextoiid]}. *)
+    [uv_if_indextoiid]}.
+
+    Requires libuv 1.16.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has if_indextoiid)] *)
 
 val gethostname : unit -> (string, Error.t) result
 (** Evaluates to the system's hostname.
@@ -42,4 +50,8 @@ val gethostname : unit -> (string, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_gethostname}
     [uv_os_gethostname]}. See
     {{:http://man7.org/linux/man-pages/man3/gethostname.3p.html}
-    [gethostname(3p)]}. *)
+    [gethostname(3p)]}.
+
+    Requires.libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_gethostname)] *)

--- a/src/passwd.mli
+++ b/src/passwd.mli
@@ -19,4 +19,8 @@ val get_passwd : unit -> (t, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_get_passwd}
     [uv_os_get_passwd]}. See
     {{:http://man7.org/linux/man-pages/man3/getpwuid_r.3p.html}
-    [getpwuid_r(3p)]}. *)
+    [getpwuid_r(3p)]}.
+
+    Requires libuv 1.9.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_get_passwd)] *)

--- a/src/path.mli
+++ b/src/path.mli
@@ -26,10 +26,18 @@ val homedir : unit -> (string, Error.t) result
 (** Evaluates to the path of the home directory.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_homedir}
-    [uv_os_homedir]}. *)
+    [uv_os_homedir]}.
+
+    Requires libuv 1.6.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_homedir)] *)
 
 val tmpdir : unit -> (string, Error.t) result
 (** Evaluates to the path of the temporary directory.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_tmpdir}
-    [uv_os_tmpdir]}. *)
+    [uv_os_tmpdir]}.
+
+    Requires libuv 1.9.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_tmpdir)] *)

--- a/src/pid.mli
+++ b/src/pid.mli
@@ -8,11 +8,19 @@ val getpid : unit -> int
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_getpid}
     [uv_os_getpid]}. See {{:http://man7.org/linux/man-pages/man3/getpid.3p.html}
-    [getpid(3p)]}. *)
+    [getpid(3p)]}.
+
+    Requires libuv 1.18.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_getpid)] *)
 
 val getppid : unit -> int
 (** Evaluates to the pid of the parent process.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_getppid}
     [uv_os_getppid]}. See
-    {{:http://man7.org/linux/man-pages/man3/getppid.3p.html} [getppid(3p)]}. *)
+    {{:http://man7.org/linux/man-pages/man3/getppid.3p.html} [getppid(3p)]}.
+
+    Requires libuv 1.16.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_getppid)] *)

--- a/src/pipe.mli
+++ b/src/pipe.mli
@@ -106,4 +106,8 @@ val chmod : t -> Mode.t list -> (unit, Error.t) result
 (** Sets pipe permissions.
 
     Binds {{:http://docs.libuv.org/en/v1.x/pipe.html#c.uv_pipe_chmod}
-    [uv_pipe_chmod]}. *)
+    [uv_pipe_chmod]}.
+
+    Requires libuv 1.16.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has pipe_chmod)] *)

--- a/src/poll.mli
+++ b/src/poll.mli
@@ -38,6 +38,20 @@ sig
     | `DISCONNECT
     | `PRIORITIZED
   ]
+  (** Binds {{:http://docs.libuv.org/en/v1.x/poll.html#c.uv_poll_event}
+      [uv_poll_event]}.
+
+      [`DISCONNECT] is implemented starting with libuv 1.9.0. On earlier
+      versions, trying to register for [`DISCONNECT] events does nothing, and,
+      correspondingly, user code cannot receive a [`DISCONNECT] event. The OCaml
+      code will still compile.
+
+      Similarly, [`PRIORITIZED] requires libuv 1.14.0.
+
+      {{!Luv.Require} Feature checks}:
+
+      - [Luv.Require.(has disconnect)]
+      - [Luv.Require.(has prioritized)] *)
 end
 
 val start :

--- a/src/process.mli
+++ b/src/process.mli
@@ -42,7 +42,10 @@ val to_parent_pipe :
 
     [?overlapped] sets
     {{:http://docs.libuv.org/en/v1.x/process.html#c.uv_stdio_flags}
-    [UV_OVERLAPPED_PIPE]}. *)
+    [UV_OVERLAPPED_PIPE]}. This requires libuv 1.21.0. On earlier versions, the
+    optional argument does nothing.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has overlapped_pipe)] *)
 
 val inherit_fd :
   fd:int ->
@@ -110,7 +113,15 @@ val spawn :
 
     Redirections for STDIN, STDOUT, STDERR that are not specified are set by Luv
     to [UV_IGNORE]. This causes libuv to open new file descriptors for the child
-    process, and redirect them to [/dev/null] or [nul]. *)
+    process, and redirect them to [/dev/null] or [nul].
+
+    [?windows_hide_console] and [?windows_hide_gui] have no effect on libuv
+    prior to 1.24.0.
+
+    {{!Luv.Require} Feature checks}:
+
+    - [Luv.Require.(has process_windows_hide_console)]
+    - [Luv.Require.(has process_windows_hide_gui)] *)
 
 val disable_stdio_inheritance : unit -> unit
 (** Disables (tries) file descriptor inheritance for inherited descriptors.

--- a/src/random.mli
+++ b/src/random.mli
@@ -19,7 +19,11 @@ val random :
 (** Fills the given buffer with bits from the system entropy source.
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_random}
-    [uv_random]}. *)
+    [uv_random]}.
+
+    Requires libuv 1.33.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has random)] *)
 
 module Sync :
 sig

--- a/src/resource.mli
+++ b/src/resource.mli
@@ -33,7 +33,12 @@ val total_memory : unit -> Unsigned.uint64
 
 val constrained_memory : unit -> Unsigned.uint64 option
 (** Binds
-    {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory}}. *)
+    {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory}}.
+
+    Requires libuv 1.29.0.
+
+    {{!Luv.Require} Feature check}:
+    [Luv.Require.(has get_constrained_memory)] *)
 
 val getpriority : int -> (int, Error.t) result
 (** Evaluates to the priority of the process with the given pid.
@@ -41,7 +46,11 @@ val getpriority : int -> (int, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_getpriority}
     [uv_os_getpriority]}. See
     {{:http://man7.org/linux/man-pages/man3/getpriority.3p.html}
-    [getpriority(3p)]}. *)
+    [getpriority(3p)]}.
+
+    Requires libuv 1.23.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_priority)] *)
 
 val setpriority : int -> int -> (unit, Error.t) result
 (** Sets the priority of the process with the given pid.
@@ -49,7 +58,11 @@ val setpriority : int -> int -> (unit, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_setpriority}
     [uv_os_setpriority]}. See
     {{:http://man7.org/linux/man-pages/man3/setpriority.3p.html}
-    [setpriority(3p)]}. *)
+    [setpriority(3p)]}.
+
+    Requires libuv 1.23.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_priority)] *)
 
 val resident_set_memory : unit -> (Unsigned.size_t, Error.t) result
 (** Evaluates to the resident set size for the current process.

--- a/src/signal.mli
+++ b/src/signal.mli
@@ -41,7 +41,11 @@ val start_oneshot : t -> int -> (unit -> unit) -> (unit, Error.t) result
 
     Binds
     {{:http://docs.libuv.org/en/v1.x/signal.html#c.uv_signal_start_oneshot}
-    [uv_signal_start_oneshot]}. *)
+    [uv_signal_start_oneshot]}.
+
+    Requires libuv 1.12.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has signal_start_oneshot)] *)
 
 val stop : t -> (unit, Error.t) result
 (** Stops the signal handle.

--- a/src/system_info.mli
+++ b/src/system_info.mli
@@ -43,4 +43,8 @@ val uname : unit -> (Uname.t, Error.t) result
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_uname}
     [uv_os_uname]}. See {{:http://man7.org/linux/man-pages/man3/uname.3p.html}
-    [uname(3p)]}. *)
+    [uname(3p)]}.
+
+    Requires libuv 1.25.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has os_uname)] *)

--- a/src/thread.mli
+++ b/src/thread.mli
@@ -35,7 +35,11 @@ val create : ?stack_size:int -> (unit -> unit) -> (t, Error.t) result
     Binds {{:http://docs.libuv.org/en/v1.x/threading.html#c.uv_thread_create}
     [uv_thread_create]}. See
     {{:http://man7.org/linux/man-pages/man3/pthread_create.3p.html}
-    [pthread_create(3p)]}. *)
+    [pthread_create(3p)]}.
+
+    [?stack_size] does nothing on libuv prior to 1.26.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has thread_stack_size)] *)
 
 val create_c :
   ?stack_size:int ->
@@ -45,7 +49,11 @@ val create_c :
 (** Like {!Luv.Thread.create}, but runs a C function by pointer.
 
     The C function should have signature [(*)(void*)]. The default value of
-    [?argument] is [NULL] (0). *)
+    [?argument] is [NULL] (0).
+
+    [?stack_size] does nothing on libuv prior to 1.26.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has thread_stack_size)] *)
 
 val join : t -> (unit, Error.t) result
 (** Waits for the given thread to terminate.

--- a/src/time.mli
+++ b/src/time.mli
@@ -14,7 +14,11 @@ val gettimeofday : unit -> (t, Error.t) result
 (** Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_gettimeofday}
     [uv_gettimeofday]}. See
     {{:http://man7.org/linux/man-pages/man3/gettimeofday.3p.html}
-    [gettimeofday(3p)]}. *)
+    [gettimeofday(3p)]}.
+
+    Requires libuv 1.28.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has gettimeofday)] *)
 
 val hrtime : unit -> Unsigned.uint64
 (** Samples the high-resolution timer.
@@ -29,4 +33,8 @@ val sleep : int -> unit
 
     Binds {{:http://docs.libuv.org/en/v1.x/misc.html#c.uv_sleep}
     [uv_sleep]}. See {{:http://man7.org/linux/man-pages/man3/sleep.3p.html}
-    [sleep(3p)]}. *)
+    [sleep(3p)]}.
+
+    Requires libuv 1.34.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has sleep)] *)

--- a/src/timer.mli
+++ b/src/timer.mli
@@ -62,4 +62,6 @@ val get_due_in : t -> int
     Binds {{:http://docs.libuv.org/en/v1.x/timer.html#c.uv_timer_get_due_in}
     [uv_timer_get_due_in]}.
 
-    @since Luv 0.5.6 (libuv 1.40.0) *)
+    Requires Luv 0.5.6 and libuv 1.40.0.
+
+    {{!Luv.Require} Feature check}: [Luv.Require.(has timer_get_due_in)] *)


### PR DESCRIPTION
Will resolve #96. cc @andyli.

- [x] Try to decrease version all the way down to ~~1.7.0, the minimum libuv version that exposes version macros~~ ~~1.0.0~~ 1.3.0.
- [x] Add documentation to the feature flags module.
- [ ] ~Add instructions on how to use the feature flags to the user guide~.
- [x] Show feature flags by every API that has them.
- [x] Link back to each API from each feature flag.
- [x] Eagerly intercept some of the more dangerous unimplemented API calls and raise some exception. Review the behaviors in general (though most behaviors are safe).
- [ ] ~~Add feature flag testing to the test suite~~.
- [x] Make sure the feature detector is using the system libuv's version number, if using the system libuv.