### PR TITLE
sa_family_t is a uint8_t on Darwin but unsigned short on Linux

### DIFF
--- a/src/c/luv_c_type_descriptions.ml
+++ b/src/c/luv_c_type_descriptions.ml
@@ -316,7 +316,7 @@ struct
 
     type storage = [ `Sockaddr_storage ] structure
     let storage : storage typ = structure "sockaddr_storage"
-    let family = field storage "ss_family" short
+    let family = field storage "ss_family" int8_t
     let () = seal storage
   end
 

--- a/test/TCP.ml
+++ b/test/TCP.ml
@@ -23,6 +23,9 @@ let with_server_and_client ~server_logic ~client_logic =
 
   let server = Luv.TCP.init () |> check_success_result "server init" in
   Luv.TCP.bind server address |> check_success_result "bind";
+  let sockaddr = Luv.TCP.getsockname server |> check_success_result "getsockname" in
+  if Luv.Sockaddr.to_string sockaddr = None then failwith "Luv.Sockaddr.to_string returned None";
+  if Luv.Sockaddr.port sockaddr = None then failwith "Luv.Sockaddr.port returned None";
   Luv.Stream.listen server begin fun result ->
     check_success_result "listen" result;
     let client = Luv.TCP.init () |> check_success_result "remote client init" in

--- a/test/UDP.ml
+++ b/test/UDP.ml
@@ -18,6 +18,9 @@ let with_sender_and_receiver ~receiver_logic ~sender_logic =
 
   let receiver = Luv.UDP.init () |> check_success_result "receiver init" in
   Luv.UDP.bind receiver address |> check_success_result "bind";
+  let sockaddr = Luv.UDP.getsockname receiver |> check_success_result "getsockname" in
+  if Luv.Sockaddr.to_string sockaddr = None then failwith "Luv.Sockaddr.to_string returned None";
+  if Luv.Sockaddr.port sockaddr = None then failwith "Luv.Sockaddr.port returned None";
 
   let sender = Luv.UDP.init () |> check_success_result "sender init" in
 


### PR DESCRIPTION
On Darwin we have:
```
typedef __uint8_t               sa_family_t;

struct sockaddr_in {
        __uint8_t       sin_len;
        sa_family_t     sin_family;
        in_port_t       sin_port;
        struct  in_addr sin_addr;
        char            sin_zero[8];
};

> #define AF_UNIX         1               /* local to host (pipes) */
> #define AF_LOCAL        AF_UNIX         /* backward compatibility */
> #define AF_INET         2               /* internetwork: UDP, TCP, etc. */
> #define AF_INET6        30              /* IPv6 */

```

On Linux we have:
```
typedef unsigned short sa_family_t;

struct sockaddr_in {
	sa_family_t sin_family;
	in_port_t sin_port;
	struct in_addr sin_addr;
	uint8_t sin_zero[8];
};

> #define PF_LOCAL        1
> #define PF_UNIX         PF_LOCAL
> #define AF_LOCAL        PF_LOCAL
> #define PF_INET         2
> #define PF_INET6        10
> #define AF_INET         PF_INET
> #define AF_INET6        PF_INET6
```

Since the relevant constants are all small, I think it's ok to use a uint8_t on both platforms. I'm not a Ctypes expert though, so there might be a better way.

Fixes #111