### PR TITLE
Windows: define sa_family_t for mingw

### DIFF
--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -31,8 +31,8 @@
 #ifndef SIGPROF
 #define SIGPROF 0
 #endif
+typedef ADDRESS_FAMILY sa_family_t;
 #endif
-
 
 
 // Callback trampolines.

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -35,6 +35,7 @@ typedef ADDRESS_FAMILY sa_family_t;
 #endif
 
 
+
 // Callback trampolines.
 //
 // We need to pass C function pointers to libuv, but call OCaml callbacks.


### PR DESCRIPTION
I'm using the Cygwin / mingw-based [Ocaml for Windows](https://fdopen.github.io/opam-repository-mingw/installation/) to build native Windows .exes. Latest `luv` failed to build because `sa_family_t` was undefined.

I couldn't find it in /usr/x86_64-w64-mingw32/sys-root/mingw/include/

There's an old (2009) complaint that Mingw doesn't define it: https://lists.gnu.org/archive/html/bug-gnulib/2009-05/msg00194.html

This patch defines it for mingw which fixes the build for me.

Let me know what you think!
