### PR TITLE
Support MSVC compiler

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -122,10 +122,17 @@ let () = Jbuild_plugin.V1.send @@ {|
  (targets generate_types_step_2.exe)
  (deps (:c generate_types_step_2.c) helpers.h shims.h)
  (action (bash "\
-  %{cc} %{c} \
-  -I '%{lib:ctypes:.}' \
-  -I %{ocaml_where} \
-  |}^ i_option ^{| -o %{targets}")))
+  if [ '%{ocaml-config:ccomp_type}' = 'msvc' ]; then \
+    %{cc} %{c} \
+    -I '%{lib:ctypes:.}' \
+    -I %{ocaml_where} \
+    |}^ i_option ^{| /Fe\"%{targets}\"; \
+  else \
+    %{cc} %{c} \
+    -I '%{lib:ctypes:.}' \
+    -I %{ocaml_where} \
+    |}^ i_option ^{| -o %{targets}; \
+  fi")))
 
 (rule
  (with-stdout-to luv_c_generated_types.ml

--- a/src/c/windows_version.h
+++ b/src/c/windows_version.h
@@ -16,4 +16,55 @@
 #include <ws2tcpip.h>
 #endif
 
+#if defined(_MSC_VER)
+# include <sys/stat.h>
+# if defined(_S_IFIFO)
+#  define S_IFIFO _S_IFIFO
+# endif
+# ifndef S_IXUSR
+#  define S_IXUSR _S_IEXEC
+# endif
+# ifndef S_IWUSR
+#  define S_IWUSR _S_IWRITE
+# endif
+# ifndef S_IRUSR
+#  define S_IRUSR _S_IREAD
+# endif
+# ifndef S_IRWXU
+#  define S_IRWXU (_S_IREAD | _S_IWRITE | _S_IEXEC)
+# endif
+/* Windows has no block devices. Defining S_IFBLK was a mistake in MinGW: https://sourceforge.net/p/mingw/bugs/1146/
+   For parity with the MinGW luv port we re-use MinGW's constant. Libuv 1.42.0 does not use S_IFBLK anyway.
+ */
+# define S_IFBLK 0x3000
+/* Windows does not support POSIX "others" and "groups". Use same settings as src.c/vendor/configure/ltmain.sh */
+# ifndef S_IXOTH
+#  define S_IXOTH 0
+# endif
+# ifndef S_IXGRP
+#  define S_IXGRP 0
+# endif
+/* Libuv 1.42 uses `| S_IRGRP | S_IROTH` and `| S_IWGRP | S_IWOTH` etc. to add POSIX permissions for "others" and "groups"
+like in src/c/vendor/libuv/src/unix/pipe.c. That means we can use zero (0) just like ltmain.sh did for
+S_IXOTH and S_IXGRP. */
+# ifndef S_IROTH
+#  define S_IROTH 0
+# endif
+# ifndef S_IRGRP
+#  define S_IRGRP 0
+# endif
+# ifndef S_IWOTH
+#  define S_IWOTH 0
+# endif
+# ifndef S_IWGRP
+#  define S_IWGRP 0
+# endif
+# ifndef S_IRWXO
+#  define S_IRWXO 0
+# endif
+# ifndef S_IRWXG
+#  define S_IRWXG 0
+# endif
+#endif
+
 #endif // #ifndef LUV_WINDOWS_VERSION_H_


### PR DESCRIPTION
Context: I'm distributing a [MSVC-compiled distribution](https://discuss.ocaml.org/t/ann-windows-friendly-ocaml-4-12-distribution-diskuv-ocaml-0-1-0/8358) of OCaml for Windows. I am using an unreleased port of `ctypes` for MSVC which passes `ctypes` own (large) internal test suite. I'd like to use libuv a) to test ctypes before releasing it and b) to include/recommend for the Windows distribution.

This PR gets the `luv` code to compile with:
* libuv 1.42 compiled with CMake from source (`/tmp/libuv` ), with all 400+ libuv tests passing except `watcher_cross_stop`
* `LUV_USE_SYSTEM_LIBUV=yes INCLUDE="$(cygpath -aw /tmp/libuv/include);$INCLUDE" LIB="$(cygpath -aw /tmp/libuv/build/Debug);$LIB" make build`

The `luv` tests also build (`LUV_USE_SYSTEM_LIBUV=yes INCLUDE="$(cygpath -aw /tmp/libuv/include);$INCLUDE" LIB="$(cygpath -aw /tmp/libuv/build/Debug);$LIB" PATH="/tmp/libuv/build/Debug:$PATH" make test`) but there are failures during test execution:
* many `TCP` tests hung
* 22 failures in `file`
* 1 failure in `fs_event` (`change`)
* 1 failure in `dns` (`getnameinfo`)

My immediate problem is I can't get the ordinary (GCC-compiled) Windows version of luv to build using the "official" OCaml CI image ... which means I don't have a baseline to resolve any test failures:

```
PS1> docker run -it ocaml/opam:windows-mingw-20H2
C:\cygwin64\home\opam>git clone https://github.com/aantron/luv.git
C:\cygwin64\home\opam>cd luv
C:\cygwin64\home\opam\luv>git switch -d 0.5.10
C:\cygwin64\home\opam\luv>git submodule update --init --recursive
C:\cygwin64\home\opam\luv>opam install . --with-test --deps-only
C:\cygwin64\home\opam\luv>make build
C:\cygwin64\home\opam\luv>make test
dune runtest --no-buffer --force
Done: 853/995 (jobs: 2)luv_unix.c:9:10: fatal error: uv.h: No such file or directory
    9 | #include <uv.h>
      |          ^~~~~~
compilation terminated.
```

So ... how did you test the Windows version? Did all of your tests pass when you did?

Thanks! Jonah