### PR TITLE
Fix invalid pointer - integer comparison warning

### DIFF
--- a/src/c/helpers.c
+++ b/src/c/helpers.c
@@ -653,7 +653,7 @@ int luv_spawn(
 
 int luv_is_invalid_handle_value(uv_os_fd_t handle)
 {
-    if (handle == -1)
+    if (handle == (uv_os_fd_t)-1)
         return 1;
     else
         return 0;


### PR DESCRIPTION
On Windows, HANDLE is a void*. The value for the invalid handle is
roughly (HANDLE)(-1), so just cast the value to avoid a warning.