### PR TITLE
Allow iovecs with buffers having length over 32bit.

### DIFF
--- a/src/c/luv_c_type_descriptions.ml
+++ b/src/c/luv_c_type_descriptions.ml
@@ -144,7 +144,7 @@ struct
     type t = [ `Buf ] structure
     let t : t typ = typedef (structure "`Buf") "uv_buf_t"
     let base = field t "base" (ptr char)
-    let len = field t "len" uint
+    let len = field t "len" ulong
     let () = seal t
   end
 

--- a/src/helpers.ml
+++ b/src/helpers.ml
@@ -50,7 +50,7 @@ struct
       let base = Ctypes.(bigarray_start array1) bigstring in
       let length = Bigarray.Array1.dim bigstring in
       Ctypes.setf iovec C.Types.Buf.base base;
-      Ctypes.setf iovec C.Types.Buf.len (Unsigned.UInt.of_int length)
+      Ctypes.setf iovec C.Types.Buf.len (Unsigned.ULong.of_int length)
     end;
     iovecs
 end


### PR DESCRIPTION
Did some quick tests in Eio and it fixes that case: See https://github.com/ocaml-multicore/eio/issues/335

There are probably more spots (outside iovec) where a (s)size_t is wrongly expressed as an Unsigned.UInt, ideally it should always be a Long.