### PR TITLE
WIP: Fix #136: use caml_ballback instead of callback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: recursive
       - uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml }}
+          ocaml-compiler: ${{ matrix.ocaml }}
       - run: opam depext -y conf-pkg-config
       - run: opam install -y --deps-only .
       - run: opam exec -- dune build -p luv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml:
+          - 4.14.0
           - 4.13.1
           - 4.02.3
         include:

--- a/src/c/generate_c_functions.ml
+++ b/src/c/generate_c_functions.ml
@@ -6,10 +6,10 @@
 let () =
   print_endline "#include \"windows_version.h\"";
   print_endline "#include <memory.h>";
+  print_endline "#include <uv.h>";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";
   print_endline "#include <caml/threads.h>";
-  print_endline "#include <uv.h>";
   print_endline "#include \"helpers.h\"";
 
   Cstubs.write_c

--- a/src/c/generate_types_start.ml
+++ b/src/c/generate_types_start.ml
@@ -5,9 +5,9 @@
 
 let () =
   print_endline "#include \"windows_version.h\"";
+  print_endline "#include <uv.h>";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";
-  print_endline "#include <uv.h>";
   print_endline "#include \"helpers.h\"";
 
   Cstubs_structs.write_c

--- a/src/c/helpers.c
+++ b/src/c/helpers.c
@@ -523,9 +523,9 @@ int luv_once_init(uv_once_t *guard)
     return 0;
 }
 
-CAMLprim value luv_set_once_callback(value callback)
+CAMLprim value luv_set_once_callback(value vcallback)
 {
-    uv_key_set(&luv_once_callback_key, (void*)callback);
+    uv_key_set(&luv_once_callback_key, (void*)vcallback);
     return Val_unit;
 }
 

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -148,7 +148,7 @@ int luv_thread_create_c(
 
 // Helpers for uv_once.
 int luv_once_init(uv_once_t *guard);
-CAMLprim value luv_set_once_callback(value callback);
+CAMLprim value luv_set_once_callback(value vcallback);
 
 
 


### PR DESCRIPTION
Adding 4.14.0 in GitHub workflow too. I don't understand the error related to esy and it is not in the scope of this PR.
