### PR TITLE
Define CAML_NAME_SPACE before including caml headers

### DIFF
--- a/src/c/generate_c_functions.ml
+++ b/src/c/generate_c_functions.ml
@@ -6,6 +6,7 @@
 let () =
   print_endline "#include \"windows_version.h\"";
   print_endline "#include <memory.h>";
+  print_endline "#define CAML_NAME_SPACE";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";
   print_endline "#include <caml/threads.h>";

--- a/src/c/generate_types_start.ml
+++ b/src/c/generate_types_start.ml
@@ -5,6 +5,7 @@
 
 let () =
   print_endline "#include \"windows_version.h\"";
+  print_endline "#define CAML_NAME_SPACE";
   print_endline "#include <caml/mlvalues.h>";
   print_endline "#include <caml/socketaddr.h>";
   print_endline "#include <uv.h>";

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #endif
 
+#define CAML_NAME_SPACE
 #include <caml/mlvalues.h>
 #include <uv.h>
 #include "shims.h"


### PR DESCRIPTION
This fixes incorrect deprecation warnings when variable names collide with name previously defined by caml headers. It is also a bit cleaner since this won't trigger the inclusion of the `<caml/compatibility.h>` header. This fixes warnings up to OCaml 4.14, the compatibility mode has been removed in OCaml 5.0.

(cc @emillon, with whom we've also seen this issue)

Fix #136 
subsumes part of #137 