### PR TITLE
Strict C warnings

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -129,7 +129,6 @@ let () = Jbuild_plugin.V1.send @@ {|
     |}^ i_option ^{| /Fe\"%{targets}\"; \
   else \
     %{cc} %{c} \
-    -Wall -Wextra -Werror=implicit-int -Werror=implicit-function-declaration -Werror=int-conversion -Werror=strict-prototypes -Werror=old-style-definition \
     -I '%{lib:ctypes:.}' \
     -I %{ocaml_where} \
     |}^ i_option ^{| -o %{targets}; \

--- a/src/c/dune
+++ b/src/c/dune
@@ -129,6 +129,7 @@ let () = Jbuild_plugin.V1.send @@ {|
     |}^ i_option ^{| /Fe\"%{targets}\"; \
   else \
     %{cc} %{c} \
+    -Wall -Wextra -Werror=implicit-int -Werror=implicit-function-declaration -Werror=int-conversion -Werror=strict-prototypes -Werror=old-style-definition \
     -I '%{lib:ctypes:.}' \
     -I %{ocaml_where} \
     |}^ i_option ^{| -o %{targets}; \

--- a/src/c/helpers.c
+++ b/src/c/helpers.c
@@ -164,7 +164,7 @@ static void luv_idle_trampoline(uv_idle_t *c_handle)
 
 uv_key_t luv_once_callback_key;
 
-static void luv_once_trampoline()
+static void luv_once_trampoline(void)
 {
     value callback = (value)uv_key_get(&luv_once_callback_key);
     caml_callback(callback, Val_unit);
@@ -293,152 +293,152 @@ static void luv_write_trampoline(uv_write_t *c_request, int status)
     caml_release_runtime_system();
 }
 
-uv_after_work_cb luv_get_after_work_trampoline()
+uv_after_work_cb luv_get_after_work_trampoline(void)
 {
     return luv_after_work_trampoline;
 }
 
-uv_alloc_cb luv_get_alloc_trampoline()
+uv_alloc_cb luv_get_alloc_trampoline(void)
 {
     return luv_alloc_trampoline;
 }
 
-uv_async_cb luv_get_async_trampoline()
+uv_async_cb luv_get_async_trampoline(void)
 {
     return luv_async_trampoline;
 }
 
-uv_check_cb luv_get_check_trampoline()
+uv_check_cb luv_get_check_trampoline(void)
 {
     return luv_check_trampoline;
 }
 
-uv_close_cb luv_get_close_trampoline()
+uv_close_cb luv_get_close_trampoline(void)
 {
     return luv_close_trampoline;
 }
 
-uv_connect_cb luv_get_connect_trampoline()
+uv_connect_cb luv_get_connect_trampoline(void)
 {
     return luv_connect_trampoline;
 }
 
-uv_connection_cb luv_get_connection_trampoline()
+uv_connection_cb luv_get_connection_trampoline(void)
 {
     return luv_connection_trampoline;
 }
 
-uv_exit_cb luv_get_exit_trampoline()
+uv_exit_cb luv_get_exit_trampoline(void)
 {
     return luv_exit_trampoline;
 }
 
-uv_exit_cb luv_null_exit_trampoline()
+uv_exit_cb luv_null_exit_trampoline(void)
 {
     return NULL;
 }
 
-uv_fs_cb luv_get_fs_trampoline()
+uv_fs_cb luv_get_fs_trampoline(void)
 {
     return luv_fs_trampoline;
 }
 
-uv_fs_cb luv_null_fs_callback_pointer()
+uv_fs_cb luv_null_fs_callback_pointer(void)
 {
     return NULL;
 }
 
-luv_fs_event_cb luv_get_fs_event_trampoline()
+luv_fs_event_cb luv_get_fs_event_trampoline(void)
 {
     return luv_fs_event_trampoline;
 }
 
-luv_fs_poll_cb luv_get_fs_poll_trampoline()
+luv_fs_poll_cb luv_get_fs_poll_trampoline(void)
 {
     return luv_fs_poll_trampoline;
 }
 
-uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline()
+uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline(void)
 {
     return luv_getaddrinfo_trampoline;
 }
 
-luv_getnameinfo_cb luv_get_getnameinfo_trampoline()
+luv_getnameinfo_cb luv_get_getnameinfo_trampoline(void)
 {
     return luv_getnameinfo_trampoline;
 }
 
-uv_idle_cb luv_get_idle_trampoline()
+uv_idle_cb luv_get_idle_trampoline(void)
 {
     return luv_idle_trampoline;
 }
 
-luv_once_cb luv_get_once_trampoline()
+luv_once_cb luv_get_once_trampoline(void)
 {
     return luv_once_trampoline;
 }
 
-uv_poll_cb luv_get_poll_trampoline()
+uv_poll_cb luv_get_poll_trampoline(void)
 {
     return luv_poll_trampoline;
 }
 
-uv_prepare_cb luv_get_prepare_trampoline()
+uv_prepare_cb luv_get_prepare_trampoline(void)
 {
     return luv_prepare_trampoline;
 }
 
-uv_random_cb luv_get_random_trampoline()
+uv_random_cb luv_get_random_trampoline(void)
 {
     return luv_random_trampoline;
 }
 
-uv_random_cb luv_null_random_trampoline()
+uv_random_cb luv_null_random_trampoline(void)
 {
     return NULL;
 }
 
-luv_read_cb luv_get_read_trampoline()
+luv_read_cb luv_get_read_trampoline(void)
 {
     return luv_read_trampoline;
 }
 
-luv_udp_recv_cb luv_get_recv_trampoline()
+luv_udp_recv_cb luv_get_recv_trampoline(void)
 {
     return luv_recv_trampoline;
 }
 
-uv_udp_send_cb luv_get_send_trampoline()
+uv_udp_send_cb luv_get_send_trampoline(void)
 {
     return luv_send_trampoline;
 }
 
-uv_shutdown_cb luv_get_shutdown_trampoline()
+uv_shutdown_cb luv_get_shutdown_trampoline(void)
 {
     return luv_shutdown_trampoline;
 }
 
-uv_signal_cb luv_get_signal_trampoline()
+uv_signal_cb luv_get_signal_trampoline(void)
 {
     return luv_signal_trampoline;
 }
 
-uv_thread_cb luv_get_thread_trampoline()
+uv_thread_cb luv_get_thread_trampoline(void)
 {
     return luv_thread_trampoline;
 }
 
-uv_timer_cb luv_get_timer_trampoline()
+uv_timer_cb luv_get_timer_trampoline(void)
 {
     return luv_timer_trampoline;
 }
 
-uv_work_cb luv_get_work_trampoline()
+uv_work_cb luv_get_work_trampoline(void)
 {
     return luv_work_trampoline;
 }
 
-uv_write_cb luv_get_write_trampoline()
+uv_write_cb luv_get_write_trampoline(void)
 {
     return luv_write_trampoline;
 }
@@ -486,12 +486,12 @@ static void luv_c_work_trampoline(uv_work_t *c_request)
     function(argument);
 }
 
-uv_after_work_cb luv_get_after_c_work_trampoline()
+uv_after_work_cb luv_get_after_c_work_trampoline(void)
 {
     return luv_after_c_work_trampoline;
 }
 
-uv_work_cb luv_get_c_work_trampoline()
+uv_work_cb luv_get_c_work_trampoline(void)
 {
     return luv_c_work_trampoline;
 }
@@ -535,7 +535,7 @@ CAMLprim value luv_set_once_callback(value callback)
 
 // Warning-suppressing wrappers.
 
-char* luv_version_string()
+char* luv_version_string(void)
 {
     return (char*)uv_version_string();
 }
@@ -599,7 +599,7 @@ int luv_os_uname(char *buffer)
 
 // Other helpers.
 
-char* luv_version_suffix()
+char* luv_version_suffix(void)
 {
     return UV_VERSION_SUFFIX;
 }

--- a/src/c/helpers.h
+++ b/src/c/helpers.h
@@ -44,7 +44,7 @@ typedef ADDRESS_FAMILY sa_family_t;
 // that is passed to them by libuv, and call it.
 
 // Not declared by libuv.
-typedef void (*luv_once_cb)();
+typedef void (*luv_once_cb)(void);
 
 // Differ from libuv declarations in const-ness of arguments. See "Warning
 // suppression" below.
@@ -63,36 +63,36 @@ typedef void (*luv_udp_recv_cb)(
     uv_udp_t *handle, ssize_t nread, uv_buf_t *buf, struct sockaddr *addr,
     unsigned int flags);
 
-uv_after_work_cb luv_get_after_work_trampoline();
-uv_alloc_cb luv_get_alloc_trampoline();
-uv_async_cb luv_get_async_trampoline();
-uv_check_cb luv_get_check_trampoline();
-uv_close_cb luv_get_close_trampoline();
-uv_connect_cb luv_get_connect_trampoline();
-uv_connection_cb luv_get_connection_trampoline();
-uv_exit_cb luv_get_exit_trampoline();
-uv_exit_cb luv_null_exit_trampoline();
-uv_fs_cb luv_get_fs_trampoline();
-uv_fs_cb luv_null_fs_callback_pointer();
-luv_fs_event_cb luv_get_fs_event_trampoline();
-luv_fs_poll_cb luv_get_fs_poll_trampoline();
-uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline();
-luv_getnameinfo_cb luv_get_getnameinfo_trampoline();
-uv_idle_cb luv_get_idle_trampoline();
-luv_once_cb luv_get_once_trampoline();
-uv_poll_cb luv_get_poll_trampoline();
-uv_prepare_cb luv_get_prepare_trampoline();
-uv_random_cb luv_get_random_trampoline();
-uv_random_cb luv_null_random_trampoline();
-luv_read_cb luv_get_read_trampoline();
-luv_udp_recv_cb luv_get_recv_trampoline();
-uv_udp_send_cb luv_get_send_trampoline();
-uv_shutdown_cb luv_get_shutdown_trampoline();
-uv_signal_cb luv_get_signal_trampoline();
-uv_thread_cb luv_get_thread_trampoline();
-uv_timer_cb luv_get_timer_trampoline();
-uv_work_cb luv_get_work_trampoline();
-uv_write_cb luv_get_write_trampoline();
+uv_after_work_cb luv_get_after_work_trampoline(void);
+uv_alloc_cb luv_get_alloc_trampoline(void);
+uv_async_cb luv_get_async_trampoline(void);
+uv_check_cb luv_get_check_trampoline(void);
+uv_close_cb luv_get_close_trampoline(void);
+uv_connect_cb luv_get_connect_trampoline(void);
+uv_connection_cb luv_get_connection_trampoline(void);
+uv_exit_cb luv_get_exit_trampoline(void);
+uv_exit_cb luv_null_exit_trampoline(void);
+uv_fs_cb luv_get_fs_trampoline(void);
+uv_fs_cb luv_null_fs_callback_pointer(void);
+luv_fs_event_cb luv_get_fs_event_trampoline(void);
+luv_fs_poll_cb luv_get_fs_poll_trampoline(void);
+uv_getaddrinfo_cb luv_get_getaddrinfo_trampoline(void);
+luv_getnameinfo_cb luv_get_getnameinfo_trampoline(void);
+uv_idle_cb luv_get_idle_trampoline(void);
+luv_once_cb luv_get_once_trampoline(void);
+uv_poll_cb luv_get_poll_trampoline(void);
+uv_prepare_cb luv_get_prepare_trampoline(void);
+uv_random_cb luv_get_random_trampoline(void);
+uv_random_cb luv_null_random_trampoline(void);
+luv_read_cb luv_get_read_trampoline(void);
+luv_udp_recv_cb luv_get_recv_trampoline(void);
+uv_udp_send_cb luv_get_send_trampoline(void);
+uv_shutdown_cb luv_get_shutdown_trampoline(void);
+uv_signal_cb luv_get_signal_trampoline(void);
+uv_thread_cb luv_get_thread_trampoline(void);
+uv_timer_cb luv_get_timer_trampoline(void);
+uv_work_cb luv_get_work_trampoline(void);
+uv_write_cb luv_get_write_trampoline(void);
 
 // Handles can have multiple outstanding callbacks, so the corresponding OCaml
 // closures are stored in an array. These are the indices into that array for
@@ -136,8 +136,8 @@ enum {
 // Helpers for setting up uv_queue_work requests that call a C function.
 int luv_add_c_function_and_argument(
     uv_work_t *c_request, intnat function, intnat argument);
-uv_after_work_cb luv_get_after_c_work_trampoline();
-uv_work_cb luv_get_c_work_trampoline();
+uv_after_work_cb luv_get_after_c_work_trampoline(void);
+uv_work_cb luv_get_c_work_trampoline(void);
 
 // Helper for calling uv_thread_create with the address of a C function.
 int luv_thread_create_c(
@@ -159,7 +159,7 @@ CAMLprim value luv_set_once_callback(value callback);
 // Ctypes is unable to emit the correct cv-qualifiers, so binding the libuv
 // functions directly with Ctypes results in noisy warnings. These wrappers
 // suppress the warnings by performing const_casts.
-char* luv_version_string();
+char* luv_version_string(void);
 char* luv_req_type_name(uv_req_type type);
 char* luv_fs_get_path(const uv_fs_t *req);
 char* luv_dlerror(const uv_lib_t *lib);
@@ -190,7 +190,7 @@ int luv_os_uname(char *buffer);
 // Miscellaneous helpers - other things that are easiest to do in C.
 
 // Ctypes.constant can't bind a char*, so we return it instead.
-char* luv_version_suffix();
+char* luv_version_suffix(void);
 
 // The arguments to uv_spawn involve complex-enough C data, that it is easiest
 // to create a wrapper function that takes simple arguments, and create the


### PR DESCRIPTION
[Enable warnings when compiling C code](https://github.com/aantron/luv/commit/6da1d0973670c2f88a9f6a9ea0411a2b0e94d86e)

In particular, enable warnings for stricter C.
See https://lwn.net/Articles/913505/.

[Fix strict-prototypes warnings](https://github.com/aantron/luv/commit/19d6559f5a918993b02faf24ab67b64902801b3b)

In all cases, the functions don't expect argument, so replacing with
void is fine. Otherwise, the functions would accept any number of
arguments.