### PR TITLE
Fix build error on windows

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -135,12 +135,12 @@ let () = Jbuild_plugin.V1.send @@ {|
   if [ '%{ocaml-config:ccomp_type}' = 'msvc' ]; then \
     %{cc} %{c} \
     -I '%{lib:ctypes:.}' \
-    -I %{ocaml_where} \
+    -I '%{ocaml_where}' \
     |}^ i_option ^{| /Fe\"%{targets}\"; \
   else \
     %{cc} %{c} \
     -I '%{lib:ctypes:.}' \
-    -I %{ocaml_where} \
+    -I '%{ocaml_where}' \
     |}^ i_option ^{| -o %{targets}; \
   fi")))
 


### PR DESCRIPTION
Fixes this error:

```
# [...]
# 100 | (rule
# 101 |  (targets generate_types_step_2.exe)
# 102 |  (deps (:c generate_types_step_2.c) helpers.h shims.h)
# .....
# 112 |     -I %{ocaml_where} \
# 113 |     -I . -o %{targets}; \
# 114 |   fi")))
# (cd _build/default/src/c && C:\msys64\usr\bin\bash.exe -e -u -o pipefail -c "if [ 'cc' = 'msvc' ]; then gcc -O2 -fno-strict-aliasing -fwrapv -mms-bitfields generate_types_step_2.c -I 'C:\...\opam\default\lib\ctypes' -I C:\...\opam\default/lib/ocaml -I . /Fe\"generate_types_step_2.exe\"; else gcc -O2 -fno-strict-aliasing -fwrapv -mms-bitfields genera[...]
# generate_types_step_2.c:3:10: fatal error: caml/mlvalues.h: No such file or directory
#     3 | #include <caml/mlvalues.h>
#       |          ^~~~~~~~~~~~~~~~~
# compilation terminated.
```

The quotes ensure that the include path is interpreted correctly.