### PR TITLE
Avoid carriage return bug when configuring libuv on Windows

### DIFF
--- a/src/c/dune
+++ b/src/c/dune
@@ -82,7 +82,7 @@ let () = Jbuild_plugin.V1.send @@ {|
   (bash "cp -r vendor/configure/* vendor/libuv/")
   (chdir vendor/libuv (progn
    (bash
-    "sh configure --host `ocamlc -config | awk '/^host:/ {print $NF}'` \
+    "sh configure --host `ocamlc -config | awk '/^host:/ {print $NF}' | tr -d '\\r'` \
       'CC=%{cc}' CFLAGS=-DNDEBUG --silent --enable-silent-rules")
    (ignore-outputs (bash
     "$([ '%{os_type}' = Unix ] && echo %{make} || echo make) V=0 -j 4 \

--- a/src/c/dune
+++ b/src/c/dune
@@ -82,7 +82,7 @@ let () = Jbuild_plugin.V1.send @@ {|
   (bash "cp -r vendor/configure/* vendor/libuv/")
   (chdir vendor/libuv (progn
    (bash
-    "sh configure --host `ocamlc -config | awk '/^host:/ {print $NF}' | tr -d '\\r'` \
+    "sh configure --host %{ocaml-config:host} \
       'CC=%{cc}' CFLAGS=-DNDEBUG --silent --enable-silent-rules")
    (ignore-outputs (bash
     "$([ '%{os_type}' = Unix ] && echo %{make} || echo make) V=0 -j 4 \


### PR DESCRIPTION
Carriage returns will appear when running the command on windows, which means that the configure script cannot function correctly because it relies on the host value to locate certain executables (such as `ar`).

This is actually the cause of #162. Fixing this doesn't completely solve (local) windows builds, as dune doesn't currently run the correct bash executable, see: https://github.com/ocaml/dune/issues/11438. This can be worked around by adding the output of `$(opam exec -- cygpath -w /bin)` to PATH.

Alternatively, this could all be replaced with `ocamlc -config-var host` which is cleaner, but that would increase the required ocaml version to 4.08. What would your preference be? @aantron

Closes #162