### PR TITLE
Use system libuv when conf-libuv is available

### DIFF
--- a/luv.opam
+++ b/luv.opam
@@ -23,6 +23,14 @@ depends: [
   "odoc" {with-doc & = "2.4.0"}
 ]
 
+depopts: [
+  "conf-libuv"
+]
+
+build-env: [
+  [LUV_USE_SYSTEM_LIBUV_DEFAULT = "%{conf-libuv:installed?yes:no}%"]
+]
+
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]

--- a/src/c/dune
+++ b/src/c/dune
@@ -13,7 +13,11 @@ let foreign_archives, uv_library_flag, include_dirs, i_option, install_h =
     match Sys.getenv "LUV_USE_SYSTEM_LIBUV" with
     | "yes" -> true
     | _ -> false
-    | exception Not_found -> false
+    | exception Not_found ->
+      match Sys.getenv "LUV_USE_SYSTEM_LIBUV_DEFAULT" with
+      | "yes" -> true
+      | _ -> false
+      | exception Not_found -> false
   in
 
   if use_system_libuv then


### PR DESCRIPTION
conf-libuv is now an optional dependency, and if installed then the system libuv will be used instead of the vendored build, by default.

This provides a more convenient way to control how luv is built. This can still be overridden by setting: `LUV_USE_SYSTEM_LIBUV=no`.

The bash commands and configure scripts required to build luv from source are not very portable, and as seen in #162, they don't work properly on Windows without additional setup. This patch useful for projects that run on windows, as they can simply add `conf-libuv` to their dependencies to use the system version, without needing manual intervention every time dependencies are installed/updated.