### PR TITLE
Replace bash use with dune-configurator

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -1,0 +1,19 @@
+module C = Configurator.V1
+
+let extra_libs c =
+  match C.ocaml_config_var_exn c "system" with
+    | "mingw64" -> ["-ldbghelp"; "-liphlpapi"; "-lole32"; "-lpsapi"; "-luserenv"]
+    | _ -> []
+
+
+let compiler_output_flag c =
+  match C.ocaml_config_var_exn c "ccomp_type" with
+    | "msvc" -> "-Fe:"
+    | _ -> "-o"
+
+
+let () =
+  C.main ~name:"luv" (fun c ->
+    C.Flags.write_sexp "extra_libs.sexp" (extra_libs c);
+    C.Flags.write_lines "compiler_output_flag" [compiler_output_flag c];
+  )

--- a/config/dune
+++ b/config/dune
@@ -1,0 +1,8 @@
+(executable
+ (name discover)
+ (libraries dune.configurator))
+
+(rule
+ (targets extra_libs.sexp compiler_output_flag)
+ (action
+  (run ./discover.exe)))

--- a/luv.opam
+++ b/luv.opam
@@ -15,6 +15,7 @@ depends: [
   "base-unix" {build}
   "ctypes" {>= "0.14.0"}
   "dune" {>= "2.7.0"}
+  "dune-configurator"
   "integers" {>= "0.3.0"}
   "ocaml" {>= "4.03.0"}
 

--- a/luv_unix.opam
+++ b/luv_unix.opam
@@ -15,6 +15,7 @@ depends: [
   "base-unix"
   "ctypes" {>= "0.14.0"}  # Ctypes.CArray.of_string.
   "dune" {>= "2.0.0"}
+  "dune-configurator"
   "luv" {>= "0.5.8"}  # uv.h.
   "ocaml" {>= "4.03.0"}
 ]

--- a/src/c/dune
+++ b/src/c/dune
@@ -43,7 +43,7 @@ let () = Jbuild_plugin.V1.send @@ {|
   (names c_generated_functions helpers)
   |}^ include_dirs ^{|)
  |}^ foreign_archives ^{|
- (c_library_flags |}^ uv_library_flag ^{| (:include extra_libs.sexp)))
+ (c_library_flags |}^ uv_library_flag ^{| (:include ../../config/extra_libs.sexp)))
 
 |}^ (if not install_h then "" else {|
 
@@ -96,15 +96,6 @@ let () = Jbuild_plugin.V1.send @@ {|
     cp vendor/libuv/libuv.1.dylib dlluv.so || \
     cp vendor/bin/libuv-1.dll dlluv.dll")))))
 
-(rule
- (targets extra_libs.sexp)
- (action (ignore-outputs (bash "\
-   if ocamlc -config | grep mingw; then \
-     echo '(-ldbghelp -liphlpapi -lole32 -lpsapi -luserenv)' > extra_libs.sexp; \
-   else \
-     echo '()' > extra_libs.sexp; \
-   fi"))))
-
 
 
 ; Everything below is the bindings generation process using ctypes. It produces
@@ -131,18 +122,12 @@ let () = Jbuild_plugin.V1.send @@ {|
 (rule
  (targets generate_types_step_2.exe)
  (deps (:c generate_types_step_2.c) helpers.h shims.h)
- (action (bash "\
-  if [ '%{ocaml-config:ccomp_type}' = 'msvc' ]; then \
-    %{cc} %{c} \
-    -I '%{lib:ctypes:.}' \
-    -I '%{ocaml_where}' \
-    |}^ i_option ^{| /Fe\"%{targets}\"; \
-  else \
-    %{cc} %{c} \
-    -I '%{lib:ctypes:.}' \
-    -I '%{ocaml_where}' \
-    |}^ i_option ^{| -o %{targets}; \
-  fi")))
+ (action (run
+    %{cc} %{c}
+    -I "%{lib:ctypes:.}"
+    -I "%{ocaml_where}"
+    |}^ i_option ^{| %{read-lines:../../config/compiler_output_flag} %{targets}
+  )))
 
 (rule
  (with-stdout-to luv_c_generated_types.ml


### PR DESCRIPTION
This makes luv more portable by removing bash usage. With this change, it is possible to avoid all bash calls when using `LUV_USE_SYSTEM_LIBUV`. See #167.

I've tested msvc's cl.exe, and it is happy with a space between `-Fe: main.exe` as long as the colon is included.